### PR TITLE
support nil *internal.Duration

### DIFF
--- a/internal/types.go
+++ b/internal/types.go
@@ -77,11 +77,17 @@ type Duration struct {
 
 // Duration returns the time.Duration for this internal Duration.
 func (d *Duration) Duration() time.Duration {
+	if d == nil {
+		return time.Duration(0)
+	}
 	return time.Duration(d.Value) * time.Second
 }
 
 // NewDuration builds an internal Duration from the passed time.Duration.
 func NewDuration(d time.Duration) *Duration {
+	if d == time.Duration(0) {
+		return nil
+	}
 	return &Duration{
 		Value: int64(d / time.Second),
 		Text:  d.String(),

--- a/internal/types_test.go
+++ b/internal/types_test.go
@@ -34,11 +34,16 @@ func TestDateTime(t *testing.T) {
 	if actual := dt.Time(); !actual.Equal(orig) {
 		t.Errorf("expected known time %v, was %v", orig, actual)
 	}
+
+	var blank *DateTime
+	if expected := (time.Time{}); blank.Time() != expected {
+		t.Errorf("expected nil DateTime to be zero time, was %v", blank.Time())
+	}
 }
 
 func TestDuration(t *testing.T) {
-	if empty := NewDuration(time.Duration(0)); empty == nil {
-		t.Errorf("expected non-nil empty duration, was %v", empty)
+	if empty := NewDuration(time.Duration(0)); empty != nil {
+		t.Errorf("expected nil empty duration, was %v", empty)
 	}
 
 	orig := time.Second * time.Duration(133)
@@ -49,5 +54,10 @@ func TestDuration(t *testing.T) {
 
 	if actual := d.Duration(); actual != orig {
 		t.Errorf("expected known duration %v, was %v", d, actual)
+	}
+
+	var blank *Duration
+	if expected := time.Duration(0); blank.Duration() != expected {
+		t.Errorf("expected nil Duration to be zero duration, was %v", blank.Duration())
 	}
 }


### PR DESCRIPTION
This will fix the bug you emailed me about. The type itself supports being nil (you can call methods on nil objects).
