### PR TITLE
use LatLng type everywhere, encode Roads API to Location

### DIFF
--- a/encoding_test.go
+++ b/encoding_test.go
@@ -1,0 +1,52 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maps
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+const (
+	jsonSnappedPoint = `{"originalIndex":null,"placeId":"helloPlace","location":{"latitude":-33.870315,"longitude":151.196532}}`
+)
+
+func TestSnappedPoint(t *testing.T) {
+	sp := SnappedPoint{
+		Location: LatLng{
+			Lat: -33.870315,
+			Lng: 151.196532,
+		},
+		PlaceID: "helloPlace",
+	}
+
+	bytes, err := json.Marshal(&sp)
+	if err != nil {
+		t.Errorf("expected ok encode of SnappedPoint, got: %v", err)
+	}
+	if string(bytes) != jsonSnappedPoint {
+		t.Errorf("expected encoded snappedPoint, was: %v", string(bytes))
+	}
+
+	var out SnappedPoint
+	err = json.Unmarshal(bytes, &out)
+	if err != nil {
+		t.Errorf("expected ok decode of SnappedPoint, got: %v", err)
+	}
+	if !reflect.DeepEqual(out, sp) {
+		t.Errorf("expected equal snappedPoint, was %+v expected %+v", out, sp)
+	}
+}

--- a/examples/roads/snaptoroad/snaptoroad.go
+++ b/examples/roads/snaptoroad/snaptoroad.go
@@ -82,7 +82,7 @@ func parsePath(path string, r *maps.SnapToRoadRequest) {
 			if err != nil {
 				usageAndExit(fmt.Sprintf("Could not parse path: %v", err))
 			}
-			r.Path = append(r.Path, maps.Location{Latitude: lat, Longitude: lng})
+			r.Path = append(r.Path, maps.LatLng{Lat: lat, Lng: lng})
 		}
 	} else {
 		usageAndExit("Path required")

--- a/examples/roads/speedlimits/speedlimits.go
+++ b/examples/roads/speedlimits/speedlimits.go
@@ -89,7 +89,7 @@ func parsePath(path string, r *maps.SpeedLimitsRequest) {
 			if err != nil {
 				usageAndExit(fmt.Sprintf("Could not parse path: %v", err))
 			}
-			r.Path = append(r.Path, maps.Location{Latitude: lat, Longitude: lng})
+			r.Path = append(r.Path, maps.LatLng{Lat: lat, Lng: lng})
 		}
 	}
 }

--- a/internal/types.go
+++ b/internal/types.go
@@ -91,3 +91,11 @@ func NewDuration(d time.Duration) *Duration {
 		Text:  d.String(),
 	}
 }
+
+// Location is the Roads API+ representation of a location on the Earth. It
+// differs only in the encoded names, which are the longer forms of 'latitude'
+// and 'longitude'.
+type Location struct {
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+}

--- a/roads.go
+++ b/roads.go
@@ -20,7 +20,6 @@ package maps // import "google.golang.org/maps"
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -71,21 +70,11 @@ func (r *SnapToRoadRequest) Get(ctx context.Context) (SnapToRoadResponse, error)
 
 // SnapToRoadRequest is the request structure for the Roads Snap to Road API.
 type SnapToRoadRequest struct {
-	// Path is the path to be snapped
-	Path []Location
-	// Interpolate is whether to interpolate a path to include all points forming the full road-geometry
+	// Path is the path to be snapped.
+	Path []LatLng
+
+	// Interpolate is whether to interpolate a path to include all points forming the full road-geometry.
 	Interpolate bool
-}
-
-// Location is a point on Earth. Please note this is different to the LatLng struct.
-// TODO: Investigate the inconsistency between this API and the other Geo WS APIs.
-type Location struct {
-	Latitude  float64 `json:"latitude"`
-	Longitude float64 `json:"longitude"`
-}
-
-func (l *Location) String() string {
-	return fmt.Sprintf("%g,%g", l.Latitude, l.Longitude)
 }
 
 // SnapToRoadResponse is an array of snapped points.
@@ -96,9 +85,11 @@ type SnapToRoadResponse struct {
 // SnappedPoint is the original path point snapped to a road.
 type SnappedPoint struct {
 	// Location of the snapped point.
-	Location `json:"location"`
+	Location LatLng `json:"location"`
+
 	// OriginalIndex is an integer that indicates the corresponding value in the original request. Not present on interpolated points.
 	OriginalIndex *int `json:"originalIndex"`
+
 	// PlaceID is a unique identifier for a place.
 	PlaceID string `json:"placeId"`
 }
@@ -161,9 +152,11 @@ const (
 // SpeedLimitsRequest is the request structure for the Roads Speed Limits API.
 type SpeedLimitsRequest struct {
 	// Path is the path to be snapped and speed limits requested.
-	Path []Location
+	Path []LatLng
+
 	// PlaceID is the PlaceIDs to request speed limits for.
 	PlaceID []string
+
 	// Units is whether to return speed limits in `SpeedLimitKPH` or `SpeedLimitMPH`. Optional, default behavior is to return results in KPH.
 	Units speedLimitUnit
 }


### PR DESCRIPTION
Resolves #16.

Note that the request types are really easy to fix, since we never encode 'latitude' or 'longitude' for them. It's just the returned `SnappedPoint` we fix.
