### PR TITLE
Renaming Distance fields

### DIFF
--- a/directions_test.go
+++ b/directions_test.go
@@ -132,7 +132,7 @@ func TestDirectionsSydneyToParramatta(t *testing.T) {
 	var steps []*Step
 	steps = append(steps, &Step{
 		HTMLInstructions: "Head <b>south</b> on <b>George St</b> toward <b>Barrack St</b>",
-		Distance:         Distance{Text: "0.4 km", Value: 366},
+		Distance:         Distance{HumanReadable: "0.4 km", Meters: 366},
 		Duration:         103000000000,
 		StartLocation:    LatLng{Lat: -33.8674944, Lng: 151.2070825},
 		EndLocation:      LatLng{Lat: -33.8707786, Lng: 151.206934},
@@ -145,7 +145,7 @@ func TestDirectionsSydneyToParramatta(t *testing.T) {
 	var legs []*Leg
 	legs = append(legs, &Leg{
 		Steps:         steps,
-		Distance:      Distance{Text: "23.8 km", Value: 23846},
+		Distance:      Distance{HumanReadable: "23.8 km", Meters: 23846},
 		Duration:      2214000000000,
 		StartLocation: LatLng{Lat: -33.8674944, Lng: 151.2070825},
 		EndLocation:   LatLng{Lat: -33.8150985, Lng: 151.0031658},

--- a/distancematrix_test.go
+++ b/distancematrix_test.go
@@ -88,7 +88,7 @@ func TestDistanceMatrixSydPyrToPar(t *testing.T) {
 					&DistanceMatrixElement{
 						Status:   "OK",
 						Duration: 2215000000000,
-						Distance: Distance{Text: "23.8 km", Value: 23846},
+						Distance: Distance{HumanReadable: "23.8 km", Meters: 23846},
 					},
 				},
 			},
@@ -97,7 +97,7 @@ func TestDistanceMatrixSydPyrToPar(t *testing.T) {
 					&DistanceMatrixElement{
 						Status:   "OK",
 						Duration: 2058000000000,
-						Distance: Distance{Text: "22.2 km", Value: 22242},
+						Distance: Distance{HumanReadable: "22.2 km", Meters: 22242},
 					},
 				},
 			},

--- a/types.go
+++ b/types.go
@@ -73,8 +73,10 @@ const (
 
 // Distance is the API representation for a distance between two points.
 type Distance struct {
-	// Text is the distance in a human displayable form. The style of display can be changed by setting `units`.
-	Text string `json:"text"`
-	// Value is the distance in meters.
-	Value int `json:"value"`
+	// HumanReadable is the human friendly distance. This is rounded and in an appropriate unit for the
+	// request. The units can be overriden with a request parameter.
+	HumanReadable string `json:"text"`
+	// Meters is the numeric distance, always in meters. This is intended to be used only in
+	// algorithmic situations, e.g. sorting results by some user specified metric.
+	Meters int `json:"value"`
 }


### PR DESCRIPTION
This makes the Golang version both more usable, and more in line with the Java client library:
https://github.com/googlemaps/google-maps-services-java/blob/master/src/main/java/com/google/maps/model/Distance.java#L20

PTAL @markmcd 
