### PR TITLE
Refactor APIs. Move HTTP and JSON code into client.go.

### DIFF
--- a/elevation_test.go
+++ b/elevation_test.go
@@ -202,18 +202,25 @@ func TestElevationCancelledContext(t *testing.T) {
 }
 
 func TestElevationRequestURL(t *testing.T) {
+	expectedQuery := "key=AIzaNotReallyAnAPIKey&locations=enc%3A_ibE_seK_seK_seK&path=enc%3A_qo%5D_%7Brc%40_seK_seK&samples=10"
+
+	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
+	defer server.s.Close()
+
 	c, _ := NewClient(WithAPIKey(apiKey))
+	c.baseURL = server.s.URL
+
 	r := &ElevationRequest{
 		Locations: []LatLng{LatLng{1, 2}, LatLng{3, 4}},
 		Path:      []LatLng{LatLng{5, 6}, LatLng{7, 8}},
 		Samples:   10,
 	}
-	req, err := r.request(c)
-	expectedQuery := "key=AIzaNotReallyAnAPIKey&locations=enc%3A_ibE_seK_seK_seK&path=enc%3A_qo%5D_%7Brc%40_seK_seK&samples=10"
+
+	_, err := c.Elevation(context.Background(), r)
 	if err != nil {
 		t.Errorf("Unexpected error in constructing request URL: %+v", err)
 	}
-	if req.URL.RawQuery != expectedQuery {
-		t.Errorf("Expected query %s, actual query %s", expectedQuery, req.URL.RawQuery)
+	if server.successful != 1 {
+		t.Errorf("Got URL(s) %v, want %s", server.failed, expectedQuery)
 	}
 }

--- a/roads_test.go
+++ b/roads_test.go
@@ -432,23 +432,37 @@ func TestSpeedLimitsWithCancelledContext(t *testing.T) {
 }
 
 func TestSnapToRoadRequestURL(t *testing.T) {
+	expectedQuery := "interpolate=true&key=AIzaNotReallyAnAPIKey&path=1%2C2%7C3%2C4"
+
+	server := mockServerForQuery(expectedQuery, 200, `{}"`)
+	defer server.s.Close()
+
 	c, _ := NewClient(WithAPIKey(apiKey))
+	c.baseURL = server.s.URL
+
 	r := &SnapToRoadRequest{
 		Path:        []LatLng{LatLng{1, 2}, LatLng{3, 4}},
 		Interpolate: true,
 	}
-	req, err := r.request(c)
-	expectedQuery := "interpolate=true&key=AIzaNotReallyAnAPIKey&path=1%2C2%7C3%2C4"
+
+	_, err := c.SnapToRoad(context.Background(), r)
 	if err != nil {
 		t.Errorf("Unexpected error in constructing request URL: %+v", err)
 	}
-	if req.URL.RawQuery != expectedQuery {
-		t.Errorf("Expected query %s, actual query %s", expectedQuery, req.URL.RawQuery)
+	if server.successful != 1 {
+		t.Errorf("Got URL(s) %v, want %s", server.failed, expectedQuery)
 	}
 }
 
 func TestSpeedLimitsRequestURL(t *testing.T) {
+	expectedQuery := "key=AIzaNotReallyAnAPIKey&path=-35.27801%2C149.12958%7C-35.28032%2C149.12907&placeId=ChIJ1Wi6I2pNFmsRQL9GbW7qABM&placeId=ChIJ58xCoGlNFmsRUEZUbW7qABM&units=MPH"
+
+	server := mockServerForQuery(expectedQuery, 200, `{}"`)
+	defer server.s.Close()
+
 	c, _ := NewClient(WithAPIKey(apiKey))
+	c.baseURL = server.s.URL
+
 	r := &SpeedLimitsRequest{
 		Path: []LatLng{
 			LatLng{Lat: -35.27801, Lng: 149.12958},
@@ -460,12 +474,12 @@ func TestSpeedLimitsRequestURL(t *testing.T) {
 		},
 		Units: SpeedLimitMPH,
 	}
-	req, err := r.request(c)
-	expectedQuery := "key=AIzaNotReallyAnAPIKey&path=-35.27801%2C149.12958%7C-35.28032%2C149.12907&placeId=ChIJ1Wi6I2pNFmsRQL9GbW7qABM&placeId=ChIJ58xCoGlNFmsRUEZUbW7qABM&units=MPH"
+
+	_, err := c.SpeedLimits(context.Background(), r)
 	if err != nil {
 		t.Errorf("Unexpected error in constructing request URL: %+v", err)
 	}
-	if req.URL.RawQuery != expectedQuery {
-		t.Errorf("Expected query %s, actual query %s", expectedQuery, req.URL.RawQuery)
+	if server.successful != 1 {
+		t.Errorf("Got URL(s) %v, want %s", server.failed, expectedQuery)
 	}
 }


### PR DESCRIPTION
If you're happy with this approach, I can do the same for the other APIs.
