### PR TITLE
	Adding page token to TextSearch request

### DIFF
--- a/places.go
+++ b/places.go
@@ -92,6 +92,10 @@ func (r *TextSearchRequest) params() url.Values {
 		q.Set("opennow", "true")
 	}
 
+	if r.PageToken != "" {
+		q.Set("pagetoken", r.PageToken)
+	}
+
 	return q
 }
 

--- a/places_test.go
+++ b/places_test.go
@@ -170,7 +170,7 @@ func TestTextSearchMinimalRequestURL(t *testing.T) {
 }
 
 func TestTextSearchAllTheThingsRequestURL(t *testing.T) {
-	expectedQuery := "key=AIzaNotReallyAnAPIKey&language=es&location=1%2C2&maxprice=2&minprice=0&opennow=true&query=Pizza+in+New+York&radius=1000"
+	expectedQuery := "key=AIzaNotReallyAnAPIKey&language=es&location=1%2C2&maxprice=2&minprice=0&opennow=true&pagetoken=NextPageToken&query=Pizza+in+New+York&radius=1000"
 
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()


### PR DESCRIPTION
PTAL @samthor 

Fixes https://github.com/googlemaps/google-maps-services-go/issues/56