### PR TITLE
Adding traffic model to Distance Matrix

### DIFF
--- a/distancematrix.go
+++ b/distancematrix.go
@@ -50,6 +50,9 @@ func (c *Client) DistanceMatrix(ctx context.Context, r *DistanceMatrixRequest) (
 	if r.TransitRoutingPreference != "" && r.Mode != TravelModeTransit {
 		return nil, errors.New("maps: mode of transit '" + string(r.Mode) + "' invalid for TransitRoutingPreference")
 	}
+	if r.Mode == TravelModeTransit && r.TrafficModel != "" {
+		return nil, errors.New("maps: cannot specify transit mode and traffic model together")
+	}
 
 	var response struct {
 		commonResponse
@@ -93,6 +96,9 @@ func (r *DistanceMatrixRequest) params() url.Values {
 	if r.ArrivalTime != "" {
 		q.Set("arrival_time", r.ArrivalTime)
 	}
+	if r.TrafficModel != "" {
+		q.Set("traffic_model", string(r.TrafficModel))
+	}
 	if len(r.TransitMode) != 0 {
 		var transitMode []string
 		for _, t := range r.TransitMode {
@@ -127,6 +133,9 @@ type DistanceMatrixRequest struct {
 	// ArrivalTime specifies the desired time of arrival for transit requests, in seconds since midnight, January 1, 1970 UTC. You cannot
 	// specify both `DepartureTime` and `ArrivalTime`. Optional.
 	ArrivalTime string
+	// TrafficModel determines the type of model that will be used when determining travel time when using depature times in the future
+	// options are TrafficModelBestGuess, TrafficModelOptimistic or TrafficModelPessimistic. Optional. Default is TrafficModelBestGuess
+	TrafficModel TrafficModel
 	// TransitMode specifies one or more preferred modes of transit. This parameter may only be specified for requests where the mode is
 	// `transit`. Valid values are `TransitModeBus`, `TransitModeSubway`, `TransitModeTrain`, `TransitModeTram`, and `TransitModeRail`.
 	// Optional.

--- a/distancematrix_test.go
+++ b/distancematrix_test.go
@@ -173,6 +173,20 @@ func TestDistanceMatrixTransitRoutingPreference(t *testing.T) {
 	}
 }
 
+func TestDistanceMatrixTrafficTransitPreference(t *testing.T) {
+	c, _ := NewClient(WithAPIKey(apiKey))
+	r := &DistanceMatrixRequest{
+		Origins:                  []string{"Sydney"},
+		Destinations:             []string{"Parramatta"},
+		TransitRoutingPreference: TransitRoutingPreferenceFewerTransfers,
+		TrafficModel:             TrafficModelPessimistic,
+	}
+
+	if _, err := c.DistanceMatrix(context.Background(), r); err == nil {
+		t.Errorf("Declaring TransitRoutingPreference without Mode=TravelModeTransit should return error")
+	}
+}
+
 func TestDistanceMatrixWithCancelledContext(t *testing.T) {
 	c, _ := NewClient(WithAPIKey(apiKey))
 	r := &DistanceMatrixRequest{
@@ -203,7 +217,7 @@ func TestDistanceMatrixFailingServer(t *testing.T) {
 }
 
 func TestDistanceMatrixRequestURL(t *testing.T) {
-	expectedQuery := "avoid=t%7Co%7Cl%7Cl%7Cs&departure_time=now&destinations=Perth%7CParramatta&key=AIzaNotReallyAnAPIKey&language=en&mode=transit&origins=Sydney%7CPyrmont&transit_mode=rail&transit_routing_preference=less_walking&units=imperial"
+	expectedQuery := "avoid=t%7Co%7Cl%7Cl%7Cs&departure_time=now&destinations=Perth%7CParramatta&key=AIzaNotReallyAnAPIKey&language=en&mode=transit&origins=Sydney%7CPyrmont&transit_mode=rail&transit_routing_preference=less_walking&units=imperial&traffic_model=pessimistic"
 
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
@@ -221,6 +235,7 @@ func TestDistanceMatrixRequestURL(t *testing.T) {
 		DepartureTime:            "now",
 		TransitMode:              []TransitMode{TransitModeRail},
 		TransitRoutingPreference: TransitRoutingPreferenceLessWalking,
+		TrafficModel:             TrafficModelPessimistic,
 	}
 
 	_, err := c.DistanceMatrix(context.Background(), r)


### PR DESCRIPTION
Added traffic models to Distance Matrix API. Pretty simple change. Note this is already present in Directions API so this keeps the two in line.