### PR TITLE
add duration_in_traffic in distancematrix response

### DIFF
--- a/distancematrix.go
+++ b/distancematrix.go
@@ -166,6 +166,8 @@ type DistanceMatrixElement struct {
 	Status string `json:"status"`
 	// Duration is the length of time it takes to travel this route.
 	Duration time.Duration `json:"duration"`
+	// DurationInTraffic is the length of time it takes to travel this route considering traffic.
+	DurationInTraffic time.Duration `json:"duration_in_traffic"`
 	// Distance is the total distance of this route.
 	Distance Distance `json:"distance"`
 }

--- a/encoding.go
+++ b/encoding.go
@@ -279,7 +279,8 @@ type safeDistanceMatrixElement DistanceMatrixElement
 // DistanceMatrixElement as per the Maps APIs.
 type encodedDistanceMatrixElement struct {
 	safeDistanceMatrixElement
-	EncDuration *internal.Duration `json:"duration"`
+	EncDuration          *internal.Duration `json:"duration"`
+	EncDurationInTraffic *internal.Duration `json:"duration_in_traffic"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler for DistanceMatrixElement. This
@@ -293,6 +294,7 @@ func (dme *DistanceMatrixElement) UnmarshalJSON(data []byte) error {
 	*dme = DistanceMatrixElement(x.safeDistanceMatrixElement)
 
 	dme.Duration = x.EncDuration.Duration()
+	dme.DurationInTraffic = x.EncDurationInTraffic.Duration()
 
 	return nil
 }


### PR DESCRIPTION
In current distancematrix response struct, there is no duration_in_traffic var, which exists in raw json responses from google api when the "departure_time" param is provided. 
So, add it into the struct.