### PR TITLE
Include Channel Parameter on Client URL

### DIFF
--- a/client.go
+++ b/client.go
@@ -39,6 +39,7 @@ type Client struct {
 	signature         []byte
 	requestsPerSecond int
 	rateLimiter       chan int
+	channel           string
 }
 
 // ClientOption is the type of constructor options for NewClient(...).
@@ -101,6 +102,14 @@ func WithHTTPClient(c *http.Client) ClientOption {
 func WithAPIKey(apiKey string) ClientOption {
 	return func(c *Client) error {
 		c.apiKey = apiKey
+		return nil
+	}
+}
+
+// WithChannel configures a Maps API client with a Channel
+func WithChannel(channel string) ClientOption {
+	return func(c *Client) error {
+		c.channel = channel
 		return nil
 	}
 }
@@ -236,6 +245,9 @@ func (c *Client) getBinary(ctx context.Context, config *apiConfig, apiReq apiReq
 }
 
 func (c *Client) generateAuthQuery(path string, q url.Values, acceptClientID bool) (string, error) {
+	if c.channel != "" {
+		q.Set("channel", c.channel)
+	}
 	if c.apiKey != "" {
 		q.Set("key", c.apiKey)
 		return q.Encode(), nil

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,27 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maps
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestClientChannelIsConfigured(t *testing.T) {
+	_, err := NewClient(WithAPIKey("AIza-Maps-API-Key"), WithChannel("Test-Channel"))
+	if err {
+		t.Errorf("Unable to create client with channel")
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -15,13 +15,12 @@
 package maps
 
 import (
-	"net/http"
 	"testing"
 )
 
 func TestClientChannelIsConfigured(t *testing.T) {
 	_, err := NewClient(WithAPIKey("AIza-Maps-API-Key"), WithChannel("Test-Channel"))
-	if err {
+	if err != nil {
 		t.Errorf("Unable to create client with channel")
 	}
 }


### PR DESCRIPTION
Google Maps API allow developers to include a client query
parameter that may be used to (for example) better control
the usage of the rate limits and calls to api (as a form of
identification)

Other libraries such as Python Library already allow developers
to set this parameter (https://github.com/googlemaps/google-maps-services-python/blob/master/googlemaps/client.py#L67)

The google developer documentation also describe this parameter:
https://developers.google.com/maps/documentation/geocoding/get-api-key
under the section 'Choosing an authentication method for your application'
->Authentication using a client ID and digital signature