### PR TITLE
Tests for StaticMap, LatLng. Clean up markdown warnings in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,12 @@ func main() {
 		Origin:      "Sydney",
 		Destination: "Perth",
 	}
-	resp, _, err := c.Directions(context.Background(), r)
+	route, _, err := c.Directions(context.Background(), r)
 	if err != nil {
 		log.Fatalf("fatal error: %s", err)
 	}
 
-	pretty.Println(resp)
+	pretty.Println(route)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Go Client for Google Maps Services
 [![GoDoc](https://godoc.org/googlemaps.github.io/maps?status.svg)](https://godoc.org/googlemaps.github.io/maps)
 
 ## Description
+
 Use Go? Want to [geocode][Geocoding API] something? Looking for [directions][Directions API]?
 Maybe [matrices of directions][Distance Matrix API]? This library brings the [Google Maps API Web
 Services] to your Go application.
@@ -13,13 +14,13 @@ Services] to your Go application.
 The Go Client for Google Maps Services is a Go Client library for the following Google Maps
 APIs:
 
- - [Directions API]
- - [Distance Matrix API]
- - [Elevation API]
- - [Geocoding API]
- - [Places API]
- - [Roads API]
- - [Time Zone API]
+- [Directions API]
+- [Distance Matrix API]
+- [Elevation API]
+- [Geocoding API]
+- [Places API]
+- [Roads API]
+- [Time Zone API]
 
 Keep in mind that the same [terms and conditions](https://developers.google.com/maps/terms) apply
 to usage of the APIs when they're accessed through this library.
@@ -38,59 +39,65 @@ If you find a bug, or have a feature suggestion, please [log an issue][issues]. 
 contribute, please read [How to Contribute][contrib].
 
 ## Requirements
- - Go 1.5 or later.
- - A Google Maps API key.
+
+- Go 1.5 or later.
+- A Google Maps API key.
 
 ### API keys
 
 Each Google Maps Web Service request requires an API key or client ID. API keys
 are freely available with a Google Account at
-https://developers.google.com/console. The type of API key you need is a 
-**Server key**. 
+[Google APIs Console][API Console]. The type of API key you need is a **Server key**.
 
 To get an API key:
 
- 1. Visit https://developers.google.com/console and log in with
+ 1. Visit [Google APIs Console][API Console] and log in with
     a Google Account.
  1. Select one of your existing projects, or create a new project.
  1. Enable the API(s) you want to use. The Go Client for Google Maps Services
     accesses the following APIs:
-    * Directions API
-    * Distance Matrix API
-    * Elevation API
-    * Geocoding API
-    * Places API
-    * Roads API
-    * Time Zone API
+    - Directions API
+    - Distance Matrix API
+    - Elevation API
+    - Geocoding API
+    - Places API
+    - Roads API
+    - Time Zone API
  1. Create a new **Server key**.
  1. If you'd like to restrict requests to a specific IP address, do so now.
- 
-For guided help, follow the instructions for the [Directions API][directions-key]. 
+
+For guided help, follow the instructions for the [Directions API][directions-key].
 You only need one API key, but remember to enable all the APIs you need.
-For even more information, see the guide to [API keys][apikey]. 
+For even more information, see the guide to [API keys][apikey].
 
 **Important:** This key should be kept secret on your server.
 
 ## Installation
 
-    $ go get googlemaps.github.io/maps
+To install the Go Client for Google Maps Services, please execute the following `go get` command.
+
+```bash
+    go get googlemaps.github.io/maps
+```
 
 ## Developer Documentation
 
 View the [reference documentation](https://godoc.org/googlemaps.github.io/maps)
 
 Additional documentation for the included  web services is available at
-https://developers.google.com/maps/ and https://developers.google.com/places/.
+[developers.google.com/maps][Maps documentation] and
+[developers.google.com/places][Places documentation].
 
- - [Directions API]
- - [Distance Matrix API]
- - [Elevation API]
- - [Geocoding API]
- - [Places API]
- - [Time Zone API]
- - [Roads API]
+- [Directions API]
+- [Distance Matrix API]
+- [Elevation API]
+- [Geocoding API]
+- [Places API]
+- [Time Zone API]
+- [Roads API]
 
 ## Usage
+
 Sample usage of the Directions API with an API key:
 
 ```go
@@ -99,9 +106,9 @@ package main
 import (
 	"log"
 
-	"googlemaps.github.io/maps"
 	"github.com/kr/pretty"
 	"golang.org/x/net/context"
+	"googlemaps.github.io/maps"
 )
 
 func main() {
@@ -136,26 +143,26 @@ package main
 import (
 	"log"
 
-	"googlemaps.github.io/maps"
 	"github.com/kr/pretty"
 	"golang.org/x/net/context"
+	"googlemaps.github.io/maps"
 )
 
 func main() {
-        c, err := maps.NewClient(maps.WithClientIDAndSignature(clientID, clientSecret))
-        if err != nil {
-            log.Fatalf("fatal error: %s", err)
-        }
-        r := &maps.DirectionsRequest{
-            Origin:      "Sydney",
-            Destination: "Perth",
-        }
-        resp, err := c.Directions(context.Background(), r)
-        if err != nil {
-            log.Fatalf("fatal error: %s", err)
-        }
+	c, err := maps.NewClient(maps.WithClientIDAndSignature("Client ID", "Client Secret"))
+	if err != nil {
+		log.Fatalf("fatal error: %s", err)
+	}
+	r := &maps.DirectionsRequest{
+		Origin:      "Sydney",
+		Destination: "Perth",
+	}
+	route, _, err := c.Directions(context.Background(), r)
+	if err != nil {
+		log.Fatalf("fatal error: %s", err)
+	}
 
-        pretty.Println(resp)
+	pretty.Println(route)
 }
 ```
 
@@ -178,6 +185,10 @@ Native objects for each of the API responses.
 
 [apikey]: https://developers.google.com/maps/faq#keysystem
 [clientid]: https://developers.google.com/maps/documentation/business/webservices/auth
+
+[API Console]: https://developers.google.com/console
+[Maps documentation]: https://developers.google.com/maps/
+[Places documentation]: https://developers.google.com/places/
 
 [Google Maps API Web Services]: https://developers.google.com/maps/documentation/webservices/
 [Directions API]: https://developers.google.com/maps/documentation/directions/

--- a/examples/staticmap/cmdline/main.go
+++ b/examples/staticmap/cmdline/main.go
@@ -1,0 +1,86 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main contains a simple command line tool for Static Maps API
+// Documentation: https://developers.google.com/maps/documentation/static-maps/
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/kr/pretty"
+	"googlemaps.github.io/maps"
+)
+
+var (
+	apiKey    = flag.String("key", "", "API Key for using Google Maps API.")
+	clientID  = flag.String("client_id", "", "ClientID for Maps for Work API access.")
+	signature = flag.String("signature", "", "Signature for Maps for Work API access.")
+	center    = flag.String("center", "", "Center the center of the map, equidistant from all edges of the map.")
+	zoom      = flag.Int("zoom", -1, "Zoom the zoom level of the map, which determines the magnification level of the map.")
+	size      = flag.String("size", "", "Size defines the rectangular dimensions of the map image.")
+	scale     = flag.Int("scale", -1, "Scale affects the number of pixels that are returned.")
+	format    = flag.String("format", "", "Format defines the format of the resulting image.")
+	maptype   = flag.String("maptype", "", "Maptype defines the type of map to construct.")
+	language  = flag.String("langauge", "", "Language defines the language to use for display of labels on map tiles.")
+	region    = flag.String("region", "", "Region the appropriate borders to display, based on geo-political sensitivities.")
+)
+
+func usageAndExit(msg string) {
+	fmt.Fprintln(os.Stderr, msg)
+	fmt.Println("Flags:")
+	flag.PrintDefaults()
+	os.Exit(2)
+}
+
+func check(err error) {
+	if err != nil {
+		log.Fatalf("fatal error: %s", err)
+	}
+}
+
+func main() {
+	flag.Parse()
+
+	var client *maps.Client
+	var err error
+	if *apiKey != "" {
+		client, err = maps.NewClient(maps.WithAPIKey(*apiKey))
+	} else if *clientID != "" || *signature != "" {
+		client, err = maps.NewClient(maps.WithClientIDAndSignature(*clientID, *signature))
+	} else {
+		usageAndExit("Please specify an API Key, or Client ID and Signature.")
+	}
+	check(err)
+
+	r := &maps.StaticMapRequest{
+		Center:   *center,
+		Zoom:     *zoom,
+		Size:     *size,
+		Scale:    *scale,
+		Format:   maps.Format(*format),
+		Language: *language,
+		Region:   *region,
+		MapType:  maps.MapType(*maptype),
+	}
+
+	resp, err := client.StaticMap(context.Background(), r)
+	check(err)
+
+	pretty.Println(resp)
+}

--- a/latlng_test.go
+++ b/latlng_test.go
@@ -1,0 +1,47 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maps
+
+import "testing"
+
+func TestParseLatLng(t *testing.T) {
+	expected := &LatLng{Lat: 12.34, Lng: 56.78}
+	actual, err := ParseLatLng("12.34,56.78")
+	if err != nil {
+		t.Errorf("Failed to parse simple LatLng %+v", err)
+	}
+
+	if !actual.AlmostEqual(expected, 0.0001) {
+		t.Errorf("LatLng failed to parse expected value. Actual '%+v', expected '%+v'", actual, expected)
+	}
+}
+
+func TestParseLatLngList(t *testing.T) {
+	expected0 := &LatLng{Lat: 12.34, Lng: 56.78}
+	expected1 := &LatLng{Lat: 14.89, Lng: 123.89}
+
+	actual, err := ParseLatLngList("12.34,56.78|14.89,123.89")
+	if err != nil {
+		t.Errorf("Failed to parse LatLngList %+v", err)
+	}
+
+	if !actual[0].AlmostEqual(expected0, 0.0001) {
+		t.Errorf("LatLng failed to parse expected value. Actual '%+v', expected '%+v'", actual[0], expected0)
+	}
+
+	if !actual[1].AlmostEqual(expected1, 0.0001) {
+		t.Errorf("LatLng failed to parse expected value. Actual '%+v', expected '%+v'", actual[1], expected1)
+	}
+}

--- a/staticmap.go
+++ b/staticmap.go
@@ -290,7 +290,7 @@ func (c *Client) StaticMap(ctx context.Context, r *StaticMapRequest) (image.Imag
 
 	if resp.StatusCode != 200 {
 		if b, err := ioutil.ReadAll(resp.Body); err == nil {
-			return nil, fmt.Errorf("Static Map API returned %d: %s", resp.StatusCode, string(b))
+			return nil, fmt.Errorf("Static Map API returned Status Code %d: %s", resp.StatusCode, string(b))
 		}
 		return nil, err
 	}

--- a/staticmap.go
+++ b/staticmap.go
@@ -290,14 +290,11 @@ func (c *Client) StaticMap(ctx context.Context, r *StaticMapRequest) (image.Imag
 
 	if resp.StatusCode != 200 {
 		if b, err := ioutil.ReadAll(resp.Body); err == nil {
-			return nil, fmt.Errorf("Static Map API returned: %s", string(b))
+			return nil, fmt.Errorf("Static Map API returned %d: %s", resp.StatusCode, string(b))
 		}
 		return nil, err
 	}
 
 	img, _, err := image.Decode(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	return img, nil
+	return img, err
 }

--- a/staticmap_test.go
+++ b/staticmap_test.go
@@ -1,0 +1,76 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maps
+
+import (
+	"fmt"
+	"image"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"golang.org/x/net/context"
+)
+
+// mockServerForQueryWithImage returns a mock server that only responds to a particular query string, and responds with an encoded Image.
+func mockServerForQueryWithImage(query string, code int, img image.Image) *countingServer {
+	server := &countingServer{}
+
+	server.s = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if query != "" && r.URL.RawQuery != query {
+			server.failed = append(server.failed, r.URL.RawQuery)
+			http.Error(w, fmt.Sprintf("Expected '%s', got '%s'", query, r.URL.RawQuery), 999)
+			return
+		}
+		server.successful++
+
+		w.WriteHeader(code)
+		w.Header().Set("Content-Type", "image/png")
+		png.Encode(w, img)
+	}))
+
+	return server
+}
+
+func TestStaticMode(t *testing.T) {
+
+	response := image.NewRGBA(image.Rect(0, 0, 640, 400))
+
+	server := mockServerForQueryWithImage("center=Brooklyn%2BBridge%252CNew%2BYork%252CNY&format=PNG&key=AIzaNotReallyAnAPIKey&language=EN-us&maptype=roadmap&region=US&scale=2&size=600x300&zoom=13", 200, response)
+	defer server.s.Close()
+	c, _ := NewClient(WithAPIKey(apiKey))
+	c.baseURL = server.s.URL
+	r := &StaticMapRequest{
+		Center:   "Brooklyn Bridge,New York,NY",
+		Size:     "600x300",
+		Zoom:     13,
+		Scale:    2,
+		Language: "EN-us",
+		Format:   "PNG",
+		Region:   "US",
+		MapType:  MapType("roadmap"),
+	}
+
+	resp, err := c.StaticMap(context.Background(), r)
+
+	if err != nil {
+		t.Errorf("r.StaticMap returned non nil error: %+v", err)
+	}
+
+	if resp.Bounds().Min.X != 0 || resp.Bounds().Min.Y != 0 || resp.Bounds().Max.X != 640 || resp.Bounds().Max.Y != 400 {
+		t.Errorf("Response image not of the correct dimensions")
+	}
+}


### PR DESCRIPTION
Also, in passing, updated the StaticMap implementation to return a decoded image, instead of the raw HTTP Response. Felt more appropriate.