### PR TITLE
Fix build failure with Go 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ go_import_path: googlemaps.github.io/maps
 
 # See https://github.com/travis-ci/gimme/blob/master/.testdata/binary-linux for known golang versions
 go:
+  - 1.6.x
   - 1.7.x
   - 1.8.x
   - tip

--- a/examples/staticmap/cmdline/main.go
+++ b/examples/staticmap/cmdline/main.go
@@ -17,13 +17,13 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"log"
 	"os"
 
 	"github.com/kr/pretty"
+	"golang.org/x/net/context"
 	"googlemaps.github.io/maps"
 )
 

--- a/staticmap.go
+++ b/staticmap.go
@@ -15,7 +15,6 @@
 package maps
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"image"
@@ -26,6 +25,8 @@ import (
 
 	_ "image/jpeg" // Loaded for image decoder
 	_ "image/png"  // Loaded for image decoder
+
+	"golang.org/x/net/context"
 )
 
 var staticMapAPI = &apiConfig{


### PR DESCRIPTION
I think the GAE/Go SDK still uses Go 1.6 mainly