### PR TITLE
add struct tag to AutocompleteResponse predictions

### DIFF
--- a/places.go
+++ b/places.go
@@ -596,7 +596,7 @@ type QueryAutocompleteRequest struct {
 
 // AutocompleteResponse is a response to a Query Autocomplete request.
 type AutocompleteResponse struct {
-	Predictions []AutocompletePrediction
+	Predictions []AutocompletePrediction `json:"predictions"`
 }
 
 // AutocompletePrediction represents a single Query Autocomplete result returned from the Google Places API Web Service.


### PR DESCRIPTION
Add struct tag to `Predictions` property in `AutocompleteResponse` to keep the json key in lower case when we marshal the struct to json.