### PR TITLE
[client_options]: added WithBaseURL method; cases of baseURL using in…

### DIFF
--- a/client.go
+++ b/client.go
@@ -106,6 +106,14 @@ func WithAPIKey(apiKey string) ClientOption {
 	}
 }
 
+// WithBaseURL configures a Maps API client with a custom base url
+func WithBaseURL(baseURL string) ClientOption {
+	return func(c *Client) error {
+		c.baseURL = baseURL
+		return nil
+	}
+}
+
 // WithChannel configures a Maps API client with a Channel
 func WithChannel(channel string) ClientOption {
 	return func(c *Client) error {

--- a/directions_test.go
+++ b/directions_test.go
@@ -139,8 +139,7 @@ func TestDirectionsTransit(t *testing.T) {
 
 	server := mockServer(200, response)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &DirectionsRequest{
 		Origin:      "Google Sydney",
 		Destination: "Glebe Pt Rd, Glebe",
@@ -268,8 +267,7 @@ func TestDirectionsSydneyToParramatta(t *testing.T) {
 
 	server := mockServer(200, response)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &DirectionsRequest{
 		Origin:      "Sydney",
 		Destination: "Parramatta",
@@ -418,8 +416,7 @@ func TestDirectionsWithCancelledContext(t *testing.T) {
 func TestDirectionsFailingServer(t *testing.T) {
 	server := mockServer(500, `{"status" : "ERROR"}`)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &DirectionsRequest{
 		Origin:      "Sydney",
 		Destination: "Parramatta",
@@ -436,8 +433,7 @@ func TestDirectionsRequestURL(t *testing.T) {
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
 
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 
 	r := &DirectionsRequest{
 		Origin:       "Sydney",
@@ -467,8 +463,7 @@ func TestTrafficModel(t *testing.T) {
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
 
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 
 	r := &DirectionsRequest{
 		Origin:        "Sydney Town Hall",
@@ -565,8 +560,7 @@ func TestFare(t *testing.T) {
 
 	server := mockServer(200, response)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &DirectionsRequest{
 		Origin:      "35.7777111, -78.625354",
 		Destination: "35.7826242, -78.6547025",
@@ -667,8 +661,7 @@ func TestNoFare(t *testing.T) {
 
 	server := mockServer(200, response)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &DirectionsRequest{
 		Origin:      "35.7777111, -78.625354",
 		Destination: "35.7826242, -78.6547025",

--- a/distancematrix_test.go
+++ b/distancematrix_test.go
@@ -51,8 +51,7 @@ func TestDistanceMatrixWithCoordinatesAndTraffic(t *testing.T) {
 }`
 	server := mockServer(200, response)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &DistanceMatrixRequest{
 		Origins:       []string{"1.315125,103.76471334"},
 		Destinations:  []string{"1.280776,103.8487"},
@@ -128,8 +127,7 @@ func TestDistanceMatrixSydPyrToPar(t *testing.T) {
 
 	server := mockServer(200, response)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &DistanceMatrixRequest{
 		Origins:      []string{"Sydney", "Pyrmont"},
 		Destinations: []string{"Parramatta"},
@@ -268,8 +266,7 @@ func TestDistanceMatrixWithCancelledContext(t *testing.T) {
 func TestDistanceMatrixFailingServer(t *testing.T) {
 	server := mockServer(500, `{"status" : "ERROR"}`)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &DistanceMatrixRequest{
 		Origins:      []string{"Sydney", "Pyrmont"},
 		Destinations: []string{},
@@ -286,8 +283,7 @@ func TestDistanceMatrixTransitRequestURL(t *testing.T) {
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
 
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 
 	r := &DistanceMatrixRequest{
 		Origins:                  []string{"Sydney", "Pyrmont"},
@@ -316,8 +312,7 @@ func TestDistanceMatrixTrafficRequestURL(t *testing.T) {
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
 
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 
 	r := &DistanceMatrixRequest{
 		Origins:       []string{"Sydney", "Pyrmont"},

--- a/elevation_test.go
+++ b/elevation_test.go
@@ -40,8 +40,7 @@ func TestElevationDenver(t *testing.T) {
 
 	server := mockServer(200, response)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &ElevationRequest{
 		Locations: []LatLng{
 			{
@@ -108,8 +107,7 @@ func TestElevationSampledPath(t *testing.T) {
 
 	server := mockServer(200, response)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &ElevationRequest{
 		Path: []LatLng{
 			{Lat: 36.578581, Lng: -118.291994},
@@ -167,8 +165,7 @@ func TestElevationPathWithNoSamples(t *testing.T) {
 func TestElevationFailingServer(t *testing.T) {
 	server := mockServer(500, `{"status" : "ERROR"}`)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &ElevationRequest{
 		Path: []LatLng{
 			{Lat: 36.578581, Lng: -118.291994},
@@ -204,8 +201,7 @@ func TestElevationRequestURL(t *testing.T) {
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
 
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 
 	r := &ElevationRequest{
 		Locations: []LatLng{{1, 2}, {3, 4}},

--- a/geocoding_test.go
+++ b/geocoding_test.go
@@ -120,8 +120,7 @@ func TestGeocodingGoogleHQ(t *testing.T) {
 
 	server := mockServer(200, response)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &GeocodingRequest{
 		Address: "1600 Amphitheatre Parkway, Mountain View, CA",
 	}
@@ -303,8 +302,7 @@ func TestGeocodingReverseGeocoding(t *testing.T) {
 
 	server := mockServer(200, response)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &GeocodingRequest{
 		LatLng: &LatLng{Lat: 40.714224, Lng: -73.961452},
 	}
@@ -409,8 +407,7 @@ func TestGeocodingWithCancelledContext(t *testing.T) {
 func TestGeocodingFailingServer(t *testing.T) {
 	server := mockServer(500, `{"status" : "ERROR"}`)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &GeocodingRequest{
 		Address: "Sydney Town Hall",
 	}
@@ -426,8 +423,7 @@ func TestGeocodingRequestURL(t *testing.T) {
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
 
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 
 	r := &GeocodingRequest{
 		Address:      "Santa Cruz",
@@ -536,8 +532,7 @@ func TestReverseGeocodingPlaceID(t *testing.T) {
 
 	server := mockServer(200, response)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &GeocodingRequest{
 		PlaceID: "ChIJ2eUgeAK6j4ARbn5u_wAGqWA",
 	}
@@ -613,8 +608,7 @@ func TestCustomPassThroughGeocodingURL(t *testing.T) {
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
 
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 	custom := make(url.Values)
 	custom["new_forward_geocoder"] = []string{"true"}
 

--- a/geolocation_test.go
+++ b/geolocation_test.go
@@ -42,8 +42,7 @@ func TestGeolocation(t *testing.T) {
 
 	server := mockServer(200, response)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &GeolocationRequest{}
 
 	resp, err := c.Geolocate(context.Background(), r)
@@ -85,8 +84,7 @@ func TestGeolocationError(t *testing.T) {
 
 	server := mockServer(200, response)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &GeolocationRequest{}
 
 	_, err := c.Geolocate(context.Background(), r)
@@ -155,8 +153,7 @@ func TestCellTowerAndWiFiRequest(t *testing.T) {
 	}))
 
 	defer server.s.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 	r := &GeolocationRequest{
 		HomeMobileCountryCode: 310,
 		HomeMobileNetworkCode: 410,

--- a/places_test.go
+++ b/places_test.go
@@ -63,8 +63,7 @@ func TestTextSearchPizzaInNewYork(t *testing.T) {
 
 	server := mockServer(200, response)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &TextSearchRequest{
 		Query: "Pizza in New York",
 	}
@@ -153,8 +152,7 @@ func TestNearbySearchMinimalRequestURL(t *testing.T) {
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
 
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 
 	r := &NearbySearchRequest{
 		Location: &LatLng{1.0, 2.0},
@@ -178,8 +176,7 @@ func TestNearbySearchMaximalRequestURL(t *testing.T) {
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
 
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 
 	r := &NearbySearchRequest{
 		Location:  &LatLng{1.0, 2.0},
@@ -276,8 +273,7 @@ func TestTextSearchMinimalRequestURL(t *testing.T) {
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
 
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 
 	r := &TextSearchRequest{
 		Query: "Pizza in New York",
@@ -300,8 +296,7 @@ func TestTextSearchAllTheThingsRequestURL(t *testing.T) {
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
 
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 
 	r := &TextSearchRequest{
 		Query:     "Pizza in New York",
@@ -360,8 +355,7 @@ func TestQueryAutocompleteMinimalRequestURL(t *testing.T) {
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
 
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 
 	r := &QueryAutocompleteRequest{
 		Input: "quay resteraunt sydney",
@@ -384,8 +378,7 @@ func TestQueryAutocompleteMaximalRequestURL(t *testing.T) {
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
 
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 
 	r := &QueryAutocompleteRequest{
 		Input:    "quay resteraunt sydney",
@@ -427,8 +420,7 @@ func TestPlaceAutocompleteMinimalRequestURL(t *testing.T) {
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
 
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 
 	r := &PlaceAutocompleteRequest{
 		Input: "quay resteraunt sydney",
@@ -451,8 +443,7 @@ func TestPlaceAutocompleteMaximalRequestURL(t *testing.T) {
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
 
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 
 	placeType, err := ParseAutocompletePlaceType("geocode")
 	if err != nil {
@@ -547,8 +538,7 @@ func TestPlaceAutocompleteWithStructuredFormatting(t *testing.T) {
 }`
 	server := mockServer(200, response)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &PlaceAutocompleteRequest{
 		Input: "Theater de Meervaart",
 		Types: AutocompletePlaceType("establishment"),
@@ -588,8 +578,7 @@ func TestRadarSearchMinimalRequestURL(t *testing.T) {
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
 
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 
 	r := &RadarSearchRequest{
 		Location: &LatLng{1, 2},
@@ -614,8 +603,7 @@ func TestRadarSearchMaximalRequestURL(t *testing.T) {
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
 
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 
 	r := &RadarSearchRequest{
 		Location: &LatLng{1, 2},
@@ -766,8 +754,7 @@ func TestPlaceDetails(t *testing.T) {
 `
 	server := mockServer(200, response)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	placeID := "ChIJ02qnq0KuEmsRHUJF4zo1x4I"
 	r := &PlaceDetailsRequest{
 		PlaceID: placeID,
@@ -879,8 +866,7 @@ func TestPlacePhoto(t *testing.T) {
 	server := mockServerForQuery(expectedQuery, 200, "An Image?")
 	defer server.s.Close()
 
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 
 	r := &PlacePhotoRequest{
 		PhotoReference: photoReference,
@@ -959,8 +945,7 @@ func TestTextSearchWithPermanentlyClosed(t *testing.T) {
   }`
 	server := mockServer(200, response)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &TextSearchRequest{
 		Query: "ABC Learning Centres in australia",
 	}
@@ -1052,8 +1037,7 @@ func TestPlaceAutocompleteJsonMarshalLowerCase(t *testing.T) {
 }`
 	server := mockServer(200, response)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &PlaceAutocompleteRequest{
 		Input: "Theater de Meervaart",
 		Types: AutocompletePlaceType("establishment"),

--- a/roads_test.go
+++ b/roads_test.go
@@ -132,8 +132,7 @@ func TestSnapToRoad(t *testing.T) {
 
 	server := mockServer(200, response)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &SnapToRoadRequest{
 		Path: []LatLng{
 			{Lat: -35.27801, Lng: 149.12958},
@@ -342,8 +341,7 @@ func TestSpeedLimit(t *testing.T) {
 }`
 	server := mockServer(200, response)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &SpeedLimitsRequest{
 		PlaceID: []string{
 			"ChIJ1Wi6I2pNFmsRQL9GbW7qABM",
@@ -434,8 +432,7 @@ func TestSnapToRoadRequestURL(t *testing.T) {
 	server := mockServerForQuery(expectedQuery, 200, `{}"`)
 	defer server.s.Close()
 
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 
 	r := &SnapToRoadRequest{
 		Path:        []LatLng{{1, 2}, {3, 4}},
@@ -457,8 +454,7 @@ func TestSpeedLimitsRequestURL(t *testing.T) {
 	server := mockServerForQuery(expectedQuery, 200, `{}"`)
 	defer server.s.Close()
 
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 
 	r := &SpeedLimitsRequest{
 		Path: []LatLng{

--- a/staticmap_test.go
+++ b/staticmap_test.go
@@ -51,8 +51,7 @@ func TestStaticMode(t *testing.T) {
 
 	server := mockServerForQueryWithImage("center=Brooklyn%2BBridge%252CNew%2BYork%252CNY&format=PNG&key=AIzaNotReallyAnAPIKey&language=EN-us&maptype=roadmap&region=US&scale=2&size=600x300&zoom=13", 200, response)
 	defer server.s.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 	r := &StaticMapRequest{
 		Center:   "Brooklyn Bridge,New York,NY",
 		Size:     "600x300",

--- a/timezone_test.go
+++ b/timezone_test.go
@@ -35,8 +35,7 @@ func TestTimezoneNevada(t *testing.T) {
 
 	server := mockServer(200, response)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &TimezoneRequest{
 		Location: &LatLng{
 			Lat: 39.6034810,
@@ -95,8 +94,7 @@ func TestTimezoneWithCancelledContext(t *testing.T) {
 func TestTimezoneFailingServer(t *testing.T) {
 	server := mockServer(500, `{"status" : "ERROR"}`)
 	defer server.Close()
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &TimezoneRequest{
 		Location: &LatLng{Lat: 36.578581, Lng: -118.291994},
 	}
@@ -112,8 +110,7 @@ func TestTimezoneRequestURL(t *testing.T) {
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
 
-	c, _ := NewClient(WithAPIKey(apiKey))
-	c.baseURL = server.s.URL
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.s.URL))
 
 	r := &TimezoneRequest{
 		Location:  &LatLng{1, 2},


### PR DESCRIPTION
Hello there!

It would be great to have a possibility to do mock responses in our functional tests from outside. 
So, I've added an ability to set baseURL as an option, to set it during client initializing. 

Thanks.