### PR TITLE
Adding back clientID to geocoding

### DIFF
--- a/geocoding.go
+++ b/geocoding.go
@@ -26,8 +26,9 @@ import (
 )
 
 var geocodingAPI = &apiConfig{
-	host: "https://maps.googleapis.com",
-	path: "/maps/api/geocode/json",
+	host:            "https://maps.googleapis.com",
+	path:            "/maps/api/geocode/json",
+	acceptsClientID: true,
 }
 
 // Geocode makes a Geocoding API request


### PR DESCRIPTION
A fix for a problem pointed out by @jqin