### PR TITLE
geocoding ZERO_RESULTS response status not an error

### DIFF
--- a/geocoding.go
+++ b/geocoding.go
@@ -46,6 +46,10 @@ func (c *Client) Geocode(ctx context.Context, r *GeocodingRequest) ([]GeocodingR
 		return nil, err
 	}
 
+	if response.Status == "ZERO_RESULTS" {
+		return []GeocodingResult{}, nil
+	}
+
 	if err := response.StatusError(); err != nil {
 		return nil, err
 	}

--- a/geocoding_test.go
+++ b/geocoding_test.go
@@ -625,3 +625,26 @@ func TestCustomPassThroughGeocodingURL(t *testing.T) {
 		t.Errorf("Got URL(s) %v, want %s", server.failed, expectedQuery)
 	}
 }
+
+func TestGeocodingZeroResults(t *testing.T) {
+	server := mockServer(200, `{"status" : "ZERO_RESULTS"}`)
+	defer server.Close()
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
+	r := &GeocodingRequest{
+		Address: "Sydney Town Hall",
+	}
+
+	response, err := c.Geocode(context.Background(), r)
+
+	if err != nil {
+		t.Errorf("Unexpected error for ZERO_RESULTS status")
+	}
+
+	if response == nil {
+		t.Errorf("Unexpected nil response for ZERO_RESULTS status")
+	}
+
+	if len(response) != 0 {
+		t.Errorf("Unexpected response for ZERO_RESULTS status")
+	}
+}


### PR DESCRIPTION
PR for #115 

When Geocoding response have status ZERO_RESULTS - it is considered as not an error, but just results with zero len.