### PR TITLE
Use standard context instead of traditional one

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,6 +16,7 @@ package maps
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -25,7 +26,6 @@ import (
 	"net/url"
 	"time"
 
-	"golang.org/x/net/context"
 	"golang.org/x/net/context/ctxhttp"
 	"googlemaps.github.io/maps/internal"
 )

--- a/directions.go
+++ b/directions.go
@@ -15,13 +15,12 @@
 package maps
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/url"
 	"strings"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 var directionsAPI = &apiConfig{

--- a/directions_test.go
+++ b/directions_test.go
@@ -15,14 +15,13 @@
 package maps
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 const apiKey = "AIzaNotReallyAnAPIKey"

--- a/distancematrix.go
+++ b/distancematrix.go
@@ -18,12 +18,11 @@
 package maps
 
 import (
+	"context"
 	"errors"
 	"net/url"
 	"strings"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 var distanceMatrixAPI = &apiConfig{

--- a/distancematrix_test.go
+++ b/distancematrix_test.go
@@ -15,10 +15,9 @@
 package maps
 
 import (
+	"context"
 	"reflect"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestDistanceMatrixWithCoordinatesAndTraffic(t *testing.T) {

--- a/elevation.go
+++ b/elevation.go
@@ -18,11 +18,10 @@
 package maps
 
 import (
+	"context"
 	"errors"
 	"net/url"
 	"strconv"
-
-	"golang.org/x/net/context"
 )
 
 var elevationAPI = &apiConfig{

--- a/elevation_test.go
+++ b/elevation_test.go
@@ -15,10 +15,9 @@
 package maps
 
 import (
+	"context"
 	"reflect"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestElevationDenver(t *testing.T) {

--- a/geocoding.go
+++ b/geocoding.go
@@ -18,11 +18,10 @@
 package maps
 
 import (
+	"context"
 	"errors"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 )
 
 var geocodingAPI = &apiConfig{

--- a/geocoding_test.go
+++ b/geocoding_test.go
@@ -15,11 +15,10 @@
 package maps
 
 import (
+	"context"
 	"net/url"
 	"reflect"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestGeocodingGoogleHQ(t *testing.T) {

--- a/geolocation.go
+++ b/geolocation.go
@@ -18,9 +18,8 @@
 package maps
 
 import (
+	"context"
 	"fmt"
-
-	"golang.org/x/net/context"
 )
 
 var geolocationAPI = &apiConfig{

--- a/geolocation_test.go
+++ b/geolocation_test.go
@@ -18,6 +18,7 @@
 package maps
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -26,7 +27,6 @@ import (
 	"testing"
 
 	"github.com/kr/pretty"
-	"golang.org/x/net/context"
 )
 
 func TestGeolocation(t *testing.T) {

--- a/places.go
+++ b/places.go
@@ -15,6 +15,7 @@
 package maps
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"image"
@@ -22,8 +23,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	// Included for image/jpeg's decoder
 	_ "image/jpeg"

--- a/places_test.go
+++ b/places_test.go
@@ -15,12 +15,11 @@
 package maps
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 func TestTextSearchPizzaInNewYork(t *testing.T) {

--- a/roads.go
+++ b/roads.go
@@ -18,11 +18,10 @@
 package maps
 
 import (
+	"context"
 	"errors"
 	"net/url"
 	"strings"
-
-	"golang.org/x/net/context"
 )
 
 var snapToRoadsAPI = &apiConfig{

--- a/roads_test.go
+++ b/roads_test.go
@@ -15,10 +15,9 @@
 package maps
 
 import (
+	"context"
 	"reflect"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestSnapToRoad(t *testing.T) {

--- a/staticmap.go
+++ b/staticmap.go
@@ -15,6 +15,7 @@
 package maps
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"image"
@@ -25,8 +26,6 @@ import (
 
 	_ "image/jpeg" // Loaded for image decoder
 	_ "image/png"  // Loaded for image decoder
-
-	"golang.org/x/net/context"
 )
 
 var staticMapAPI = &apiConfig{

--- a/staticmap_test.go
+++ b/staticmap_test.go
@@ -15,14 +15,13 @@
 package maps
 
 import (
+	"context"
 	"fmt"
 	"image"
 	"image/png"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 // mockServerForQueryWithImage returns a mock server that only responds to a particular query string, and responds with an encoded Image.

--- a/timezone.go
+++ b/timezone.go
@@ -18,12 +18,11 @@
 package maps
 
 import (
+	"context"
 	"errors"
 	"net/url"
 	"strconv"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 var timezoneAPI = &apiConfig{

--- a/timezone_test.go
+++ b/timezone_test.go
@@ -15,12 +15,12 @@
 package maps
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/kr/pretty"
-	"golang.org/x/net/context"
 )
 
 func TestTimezoneNevada(t *testing.T) {


### PR DESCRIPTION
Replace "golang.org/x/net/context" with "context".