### PR TITLE
Fix for the Center point to work with coordinates

### DIFF
--- a/staticmap.go
+++ b/staticmap.go
@@ -227,7 +227,7 @@ func (r *StaticMapRequest) params() url.Values {
 	q := make(url.Values)
 
 	if r.Center != "" {
-		q.Set("center", url.QueryEscape(r.Center))
+		q.Set("center", r.Center)
 	}
 
 	if r.Zoom > 0 {


### PR DESCRIPTION
The static maps was not working when using coordinates instead of location name for the Center point.

I removed the url.QueryEscape for the r.Center which fixes this issue.