### PR TITLE
Complete geocoding

### DIFF
--- a/geocoding.go
+++ b/geocoding.go
@@ -183,6 +183,7 @@ type GeocodingResult struct {
 	Geometry          AddressGeometry    `json:"geometry"`
 	Types             []string           `json:"types"`
 	PlaceID           string             `json:"place_id"`
+	Name              string             `json:"name"`
 }
 
 // AddressComponent is a part of an address

--- a/geocoding.go
+++ b/geocoding.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// More information about Google Distance Matrix API is available on
-// https://developers.google.com/maps/documentation/distancematrix/
+// More information about Google Geocoding API is available on
+// https://developers.google.com/maps/documentation/geocoding
 
 package maps
 


### PR DESCRIPTION
I've added the `Name` field in the `GeocodingResult` because it seems new
(cf https://maps.googleapis.com/maps/api/place/details/json?place_id=ChIJqUygGhty5kcR3q67dwPFncI&key=yourApiKey)

And it seems useful to have it. For example with the previous link, which is using the placeId of a train station in Paris, the formatted address doesn't not include the name of this train station (and just the postal code and the city)

PS: I've also updated the link to the documentation