### PR TITLE
Expose author photo in place details request

### DIFF
--- a/places.go
+++ b/places.go
@@ -598,6 +598,8 @@ type PlaceReview struct {
 	AuthorName string `json:"author_name,omitempty"`
 	// AuthorURL the URL to the user's Google+ profile, if available.
 	AuthorURL string `json:"author_url,omitempty"`
+	// AuthorPhoto the Google+ profile photo url of the user who submitted the review, if available.
+	AuthorProfilePhoto string `json:"profile_photo_url"`
 	// Language an IETF language code indicating the language used in the user's review.
 	// This field contains the main language tag only, and not the secondary tag
 	// indicating country or region.

--- a/places_test.go
+++ b/places_test.go
@@ -759,7 +759,8 @@ func TestPlaceDetails(t *testing.T) {
                   "rating" : 1,
                   "type" : "overall"
                }
-            ],
+			],
+			"profile_photo_url": "https://lh3.googleusercontent.com/-EXtIWgDBHgs/AAAAAAAAAAI/AAAAAAAAAAA/AIcfdXCXHH76RsCp2i2B0qjO1WngDfIrQQ/s120-p-rw-no-mo/photo.jpg",
             "author_name" : "Rachel Lewis",
             "author_url" : "https://plus.google.com/114299517944848975298",
             "language" : "en",
@@ -843,6 +844,11 @@ func TestPlaceDetails(t *testing.T) {
 	authorName := "Rachel Lewis"
 	if authorName != resp.Reviews[0].AuthorName {
 		t.Errorf("expected %+v, was %+v", authorName, resp.Reviews[0].AuthorName)
+	}
+
+	authorProfilePhoto := "https://lh3.googleusercontent.com/-EXtIWgDBHgs/AAAAAAAAAAI/AAAAAAAAAAA/AIcfdXCXHH76RsCp2i2B0qjO1WngDfIrQQ/s120-p-rw-no-mo/photo.jpg"
+	if authorProfilePhoto != resp.Reviews[0].AuthorProfilePhoto {
+		t.Errorf("expected %+v, was %+v", authorProfilePhoto, resp.Reviews[0].AuthorProfilePhoto)
 	}
 
 	authorURL := "https://plus.google.com/114299517944848975298"


### PR DESCRIPTION
Added 'AuthorProfilePhoto' to the place details results along with the proper test as per Google's API: https://developers.google.com/places/web-service/details