### PR TITLE
Added `partial_match` and `plus_code` to GeocodingResult

### DIFF
--- a/examples/geocoding/cmdline/main.go
+++ b/examples/geocoding/cmdline/main.go
@@ -111,7 +111,7 @@ func parseComponents(components string, r *maps.GeocodingRequest) {
 		case "country":
 			r.Components[maps.ComponentCountry] = i[1]
 		default:
-			log.Fatalf("parseComponents: wrong component name given %#v", i[0])
+			log.Fatalf("parseComponents: component name %#v unknown", i[0])
 		}
 	}
 }

--- a/examples/geocoding/cmdline/main.go
+++ b/examples/geocoding/cmdline/main.go
@@ -89,22 +89,29 @@ func main() {
 }
 
 func parseComponents(components string, r *maps.GeocodingRequest) {
-	if components != "" {
-		c := strings.Split(components, "|")
-		for _, cf := range c {
-			i := strings.Split(cf, ":")
-			switch i[0] {
-			case "route":
-				r.Components[maps.ComponentRoute] = i[1]
-			case "locality":
-				r.Components[maps.ComponentLocality] = i[1]
-			case "administrative_area":
-				r.Components[maps.ComponentAdministrativeArea] = i[1]
-			case "postal_code":
-				r.Components[maps.ComponentPostalCode] = i[1]
-			case "country":
-				r.Components[maps.ComponentCountry] = i[1]
-			}
+	if components == "" {
+		return
+	}
+	if r.Components == nil {
+		r.Components = make(map[maps.Component]string)
+	}
+
+	c := strings.Split(components, "|")
+	for _, cf := range c {
+		i := strings.Split(cf, ":")
+		switch i[0] {
+		case "route":
+			r.Components[maps.ComponentRoute] = i[1]
+		case "locality":
+			r.Components[maps.ComponentLocality] = i[1]
+		case "administrative_area":
+			r.Components[maps.ComponentAdministrativeArea] = i[1]
+		case "postal_code":
+			r.Components[maps.ComponentPostalCode] = i[1]
+		case "country":
+			r.Components[maps.ComponentCountry] = i[1]
+		default:
+			log.Fatalf("parseComponents: wrong component name given %#v", i[0])
 		}
 	}
 }

--- a/geocoding.go
+++ b/geocoding.go
@@ -206,6 +206,37 @@ type GeocodingResult struct {
 	// suggest an alternative address.
 	// Suggestions triggered in this way will also be marked as a partial match.
 	PartialMatch bool `json:"partial_match"`
+
+	// PlusCode (see https://en.wikipedia.org/wiki/Open_Location_Code and https://plus.codes/)
+	// is an encoded location reference, derived from latitude and longitude coordinates,
+	// that represents an area: 1/8000th of a degree by 1/8000th of a degree (about 14m x 14m at the equator)
+	// or smaller.
+	//
+	// Plus codes can be used as a replacement for street addresses in places where they do not exist
+	// (where buildings are not numbered or streets are not named).
+	// The plus code is formatted as a global code and a compound code:
+	// Typically, both the global code and compound code are returned.
+	// However, if the result is in a remote location (for example, an ocean or desert)
+	// only the global code may be returned.
+	PlusCode AddressPlusCode `json:"plus_code"`
+}
+
+// AddressPlusCode (see https://en.wikipedia.org/wiki/Open_Location_Code and https://plus.codes/)
+// is an encoded location reference, derived from latitude and longitude coordinates,
+// that represents an area: 1/8000th of a degree by 1/8000th of a degree (about 14m x 14m at the equator)
+// or smaller.
+//
+// Plus codes can be used as a replacement for street addresses in places where they do not exist
+// (where buildings are not numbered or streets are not named).
+// The plus code is formatted as a global code and a compound code:
+// Typically, both the global code and compound code are returned.
+// However, if the result is in a remote location (for example, an ocean or desert)
+// only the global code may be returned.
+type AddressPlusCode struct {
+	// GlobalCode is a 4 character area code and 6 character or longer local code (849VCWC8+R9).
+	GlobalCode string `json:"global_code"`
+	// CompoundCode is a 6 character or longer local code with an explicit location (CWC8+R9, Mountain View, CA, USA).
+	CompoundCode string `json:"compound_code"`
 }
 
 // AddressComponent is a part of an address

--- a/geocoding.go
+++ b/geocoding.go
@@ -193,6 +193,19 @@ type GeocodingResult struct {
 	Geometry          AddressGeometry    `json:"geometry"`
 	Types             []string           `json:"types"`
 	PlaceID           string             `json:"place_id"`
+
+	// PartialMatch indicates that the geocoder did not return an exact match for
+	// the original request, though it was able to match part of the requested address.
+	// You may wish to examine the original request for misspellings and/or an incomplete address.
+	// Partial matches most often occur for street addresses that do not exist within the
+	// locality you pass in the request.
+	// Partial matches may also be returned when a request matches two or more locations in
+	// the same locality. For example, "21 Henr St, Bristol, UK" will return a partial match
+	// for both Henry Street and Henrietta Street.
+	// Note that if a request includes a misspelled address component, the geocoding service may
+	// suggest an alternative address.
+	// Suggestions triggered in this way will also be marked as a partial match.
+	PartialMatch bool `json:"partial_match"`
 }
 
 // AddressComponent is a part of an address

--- a/geocoding_test.go
+++ b/geocoding_test.go
@@ -109,6 +109,7 @@ func TestGeocodingGoogleHQ(t *testing.T) {
                     }
                 }
             },
+            "partial_math": false,
             "place_id": "ChIJ2eUgeAK6j4ARbn5u_wAGqWA",
             "types": [
                 "street_address"
@@ -186,8 +187,9 @@ func TestGeocodingGoogleHQ(t *testing.T) {
 			},
 			Types: nil,
 		},
-		PlaceID: "ChIJ2eUgeAK6j4ARbn5u_wAGqWA",
-		Types:   []string{"street_address"},
+		PartialMatch: false,
+		PlaceID:      "ChIJ2eUgeAK6j4ARbn5u_wAGqWA",
+		Types:        []string{"street_address"},
 	}
 
 	if !reflect.DeepEqual(resp[0], correctResponse) {


### PR DESCRIPTION
Google maps API has  field "partial_math" in results, and it's helpfull for cases when we need to know if result is not exact
https://developers.google.com/maps/documentation/geocoding/intro#Results
And for plus_code https://developers.google.com/maps/documentation/geocoding/intro#pluscode

In this case it's reasonable to add such fields in GeocodingResult