### PR TITLE
Improve ReverseGeocode error handling

### DIFF
--- a/geocoding.go
+++ b/geocoding.go
@@ -73,6 +73,10 @@ func (c *Client) ReverseGeocode(ctx context.Context, r *GeocodingRequest) ([]Geo
 		return nil, err
 	}
 
+	if response.Status == "ZERO_RESULTS" {
+		return []GeocodingResult{}, nil
+	}
+
 	if err := response.StatusError(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This makes the error handing in ReverseGeocode consistent with Geocode.

Updates issue #135.