### PR TITLE
a new contract for map styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ APIs:
 - [Places API]
 - [Roads API]
 - [Time Zone API]
+- [Maps Static API]
 
 Keep in mind that the same [terms and conditions](https://developers.google.com/maps/terms) apply
 to usage of the APIs when they're accessed through this library.
@@ -63,6 +64,7 @@ To get an API key:
     - Places API
     - Roads API
     - Time Zone API
+    - Maps Static API
  1. Create a new **Server key**.
  1. If you'd like to restrict requests to a specific IP address, do so now.
 
@@ -95,6 +97,7 @@ Additional documentation for the included  web services is available at
 - [Places API]
 - [Time Zone API]
 - [Roads API]
+- [Maps Static API]
 
 ## Usage
 
@@ -200,6 +203,7 @@ Native objects for each of the API responses.
 [Places API]: https://developers.google.com/places/web-service/
 [Roads API]: https://developers.google.com/maps/documentation/roads/
 [Time Zone API]: https://developers.google.com/maps/documentation/timezone/
+[Maps Static API]: https://developers.google.com/maps/documentation/maps-static/
 
 [issues]: https://github.com/googlemaps/google-maps-services-go/issues
 [contrib]: https://github.com/googlemaps/google-maps-services-go/blob/master/CONTRIB.md

--- a/examples/staticmap/cmdline/main.go
+++ b/examples/staticmap/cmdline/main.go
@@ -37,7 +37,7 @@ var (
 	scale     = flag.Int("scale", -1, "Scale affects the number of pixels that are returned.")
 	format    = flag.String("format", "", "Format defines the format of the resulting image.")
 	maptype   = flag.String("maptype", "", "Maptype defines the type of map to construct.")
-	language  = flag.String("langauge", "", "Language defines the language to use for display of labels on map tiles.")
+	language  = flag.String("language", "", "Language defines the language to use for display of labels on map tiles.")
 	region    = flag.String("region", "", "Region the appropriate borders to display, based on geo-political sensitivities.")
 )
 

--- a/staticmap.go
+++ b/staticmap.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"image"
 	"io/ioutil"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -107,13 +108,14 @@ type CustomIcon struct {
 }
 
 func (c CustomIcon) String() string {
-	r := []string{}
+	var r []string
+
 	if c.IconURL != "" {
 		r = append(r, fmt.Sprintf("icon:%s", c.IconURL))
 	}
 
 	if c.Anchor != "" {
-		r = append(r, fmt.Sprintf("anchor:%s", string(c.Anchor)))
+		r = append(r, fmt.Sprintf("anchor:%s", c.Anchor))
 	}
 
 	return strings.Join(r, "|")
@@ -136,7 +138,7 @@ type Marker struct {
 }
 
 func (m Marker) String() string {
-	r := []string{}
+	var r []string
 
 	if m.CustomIcon != (CustomIcon{}) {
 		r = append(r, m.CustomIcon.String())
@@ -150,7 +152,7 @@ func (m Marker) String() string {
 		}
 
 		if m.Size != "" {
-			r = append(r, fmt.Sprintf("Size:%s", m.Size))
+			r = append(r, fmt.Sprintf("size:%s", m.Size))
 		}
 	}
 
@@ -179,7 +181,8 @@ type Path struct {
 }
 
 func (p Path) String() string {
-	r := []string{}
+	var r []string
+
 	if p.Color != "" {
 		r = append(r, fmt.Sprintf("color:%s", p.Color))
 	}
@@ -189,88 +192,17 @@ func (p Path) String() string {
 	}
 
 	if p.Weight != 0 {
-		r = append(r, fmt.Sprintf("weight:%s", strconv.Itoa(p.Weight)))
+		r = append(r, fmt.Sprintf("weight:%d", p.Weight))
 	}
 
 	if p.Geodesic {
-		r = append(r, fmt.Sprintf("geodesic:%s", strconv.FormatBool(p.Geodesic)))
+		r = append(r, "geodesic:true")
 	}
 
 	for _, l := range p.Location {
 		r = append(r, l.String())
 	}
 	return strings.Join(r, "|")
-}
-
-// MapStyle defines a custom style to alter the presentation of a specific feature
-// (roads, parks, and other features) of the map.
-type MapStyle map[FeatureName]Elements
-
-// mapStyles receives an object of type MapStyle and processes it
-// into a slice of valid Map Style Rules, each of which are parameter strings
-// formatted in accordance with the Google Static Maps Style Maps API and
-// ready for query string encoding.
-func mapStyles(ms MapStyle) []string {
-	features := make([]string, 0)
-	for feature, elements := range ms {
-		if es := elementsString(elements); es != "" {
-			features = append(features, fmt.Sprintf("feature:%s|%s", feature, es))
-		}
-	}
-	return features
-}
-
-// FeatureName is the name of a Feature which is receiving Map Styling for it's Elements.
-type FeatureName string
-
-// ElementName is the name of an Element which is receiving Map Styling Rules.
-type ElementName string
-
-// Elements is a map of per-Element Style Rules.
-type Elements map[ElementName]StyleRules
-
-// elementsString receives an object of type Elements and for each
-// Map Element within it, processes it's Map Style Rules into a string
-// formatted in accordance with the Google Static Maps Style Maps API.
-func elementsString(me Elements) string {
-	str := ""
-	for element, rules := range me {
-		if rs := rulesString(rules); rs != "" {
-			if str == "" {
-				str = fmt.Sprintf("|%s|%s", element, rs)
-			} else {
-				str = fmt.Sprintf("%s|%s|%s", str, element, rs)
-			}
-		}
-	}
-	return str
-}
-
-// StyleItem is a Map Item which can have a Style Item defined.
-type StyleItem string
-
-// StyleOption is the value being defined for a specific Style item.
-type StyleOption string
-
-// StyleRules is a map of Map Style Items, for each declared Item a single Style Option must be defined.
-type StyleRules map[StyleItem]StyleOption
-
-// rulesString receives an object of StyleRules and for each
-// Map Style Rule within it, processes it into a string
-// formatted in accordance with the Google Static Maps Style Maps API.
-func rulesString(sr StyleRules) string {
-	str := ""
-	for k, v := range sr {
-		if v != "" {
-			rule := fmt.Sprintf("%s:%s", k, v)
-			if str == "" {
-				str = rule
-			} else {
-				str = fmt.Sprintf("%s|%s:%s", rule, k, v)
-			}
-		}
-	}
-	return str
 }
 
 // StaticMapRequest is the functional options struct for staticMap.Get
@@ -306,8 +238,8 @@ type StaticMapRequest struct {
 	// Visible specifies one or more locations that should remain visible on the map,
 	// though no markers or other indicators will be displayed.
 	Visible []LatLng
-	// MapStyles (optional) contains map styles on a per-feature basis.
-	MapStyles MapStyle
+	// MapStyles (optional) contains map styles.
+	MapStyles []string
 }
 
 func (r *StaticMapRequest) params() url.Values {
@@ -341,36 +273,30 @@ func (r *StaticMapRequest) params() url.Values {
 		q.Set("maptype", string(r.MapType))
 	}
 
-	if len(r.Markers) > 0 {
-		for _, m := range r.Markers {
-			q.Add("markers", m.String())
-		}
+	for _, m := range r.Markers {
+		q.Add("markers", m.String())
 	}
 
-	if len(r.Paths) > 0 {
-		for _, ps := range r.Paths {
-			q.Add("path", ps.String())
-		}
+	for _, ps := range r.Paths {
+		q.Add("path", ps.String())
 	}
 
 	if len(r.Visible) > 0 {
-		t := []string{}
-		for _, l := range r.Visible {
-			t = append(t, l.String())
+		t := make([]string, len(r.Visible))
+		for i, l := range r.Visible {
+			t[i] = l.String()
 		}
 		q.Set("visible", strings.Join(t, "|"))
 	}
 
-	for _, style := range mapStyles(r.MapStyles) {
-		if style != "" {
-			q.Add("style", style)
-		}
+	for _, style := range r.MapStyles {
+		q.Add("style", style)
 	}
 
 	return q
 }
 
-//StaticMap make a StaticMap API request
+// StaticMap makes a StaticMap API request.
 func (c *Client) StaticMap(ctx context.Context, r *StaticMapRequest) (image.Image, error) {
 	if len(r.Markers) == 0 && r.Center == "" && r.Zoom == 0 {
 		return nil, errors.New("maps: Center & Zoom required if Markers empty")
@@ -385,11 +311,12 @@ func (c *Client) StaticMap(ctx context.Context, r *StaticMapRequest) (image.Imag
 	}
 	defer resp.data.Close()
 
-	if resp.statusCode != 200 {
-		if b, err := ioutil.ReadAll(resp.data); err == nil {
-			return nil, fmt.Errorf("Static Map API returned Status Code %d: %s", resp.statusCode, string(b))
+	if resp.statusCode != http.StatusOK {
+		b, err := ioutil.ReadAll(resp.data)
+		if err != nil {
+			return nil, err
 		}
-		return nil, err
+		return nil, fmt.Errorf("Maps Static API: %d - %s", resp.statusCode, b)
 	}
 
 	img, _, err := image.Decode(resp.data)

--- a/staticmap_test.go
+++ b/staticmap_test.go
@@ -20,7 +20,6 @@ import (
 	"image/png"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"golang.org/x/net/context"
@@ -76,57 +75,12 @@ func TestStaticMode(t *testing.T) {
 
 func TestMapStyles(t *testing.T) {
 	r := StaticMapRequest{
-		Size:  "600x600",
-		Scale: 2,
-		Markers: []Marker{
-			Marker{
-				Location: []LatLng{
-					LatLng{
-						Lat: 51.477222,
-						Lng: 0,
-					},
-				},
-			},
-		},
-		Zoom: 13,
-
-		MapStyles: MapStyle{
-			"poi.attraction": Elements{
-				"all": StyleRules{
-					"visibility": "off",
-				},
-			},
-			"water": Elements{
-				"geometry.fill": StyleRules{
-					"color": "0xFF0000",
-				},
-			},
-			"landscape.natural": Elements{
-				"geometry": StyleRules{
-					"color": "0x0000FF",
-					"width": "50",
-				},
-			},
+		MapStyles: []string{
+			"x", "y",
 		},
 	}
 	values := r.params()
-	if c := strings.Count(values.Encode(), "style"); c != 3 {
-		t.Errorf("Generate query string does not contain sufficient Style parameters (found %d)", c)
+	if q := values.Encode(); q != "style=x&style=y" {
+		t.Errorf("Generated query string is wrong: %s", q)
 	}
-
-	// Uncomment this block of code to write a styled map to ./mapstyles.jpeg
-	/*
-		apiKey := "<YOUR API KEY HERE>"
-		client, err := NewClient(WithAPIKey(apiKey))
-		if err != nil {
-			t.Fatalf("Failed to create client (error: %s)", err.Error())
-		}
-		image, err := client.StaticMap(context.Background(), &r)
-		if err != nil {
-			t.Fatalf("Failed to create styled map image (error: %s)", err.Error())
-		}
-		buffer := &bytes.Buffer{}
-		jpeg.Encode(buffer, image, nil)
-		ioutil.WriteFile("./mapstyles.jpeg", buffer.Bytes(), os.ModePerm)
-	*/
 }


### PR DESCRIPTION
Hi!
Recently created design for Maps Static API integration works wrong. 
Problems:
1. Static map styles have [priorities](https://developers.google.com/maps/documentation/maps-static/styling#style-syntax). 

> Style rules are applied in the order that you specify. Do not combine multiple operations into a single style operation. Instead, define each operation as a separate entry in the style array.
>
> Note: Order is important, as some operations are not commutative. Features and/or elements that are modified through style operations (usually) already have existing styles. The operations act on those existing styles, if present.

But Golang maps do not guarantee a sequence. Hence the following style defined as a map works ambiguously:
```
all:
  geometry:
    color: "0xe8eff2"
water:
  geometry:
    color: "0x9fddff"
```
It can be converted in two different queries:
```
style=feature:all|element:geometry|color:0xe8eff2&style=feature:water|element:geometry|color:0x9fddff
```
or
```
style=feature:water|element:geometry|color:0x9fddff&style=feature:all|element:geometry|color:0xe8eff2
```
Both queries generate different pictures. 
2. Golang maps add complexity to test the resulted format. A test should parse a string back then both resulted and expected data should be compared in a tricky deep manner.
3. Waste CPU in maps to strings converting on each request.
  
I propose to make a breaking change. Let's use a list of [Google styles](https://developers.google.com/maps/documentation/maps-static/styling#style-syntax) instead of maps:
```
- feature:all|element:geometry|color:0xe8eff
- feature:water|element:geometry|color:0x9fddff
```