### PR TITLE
make sessiontoken optional in autocomplete

### DIFF
--- a/places.go
+++ b/places.go
@@ -389,8 +389,7 @@ func (r *PlaceDetailsRequest) params() url.Values {
 		q.Set("fields", strings.Join(placeDetailsFieldMasksAsStringArray(r.Fields), ","))
 	}
 
-	st := uuid.UUID(r.SessionToken).String()
-	if st != "00000000-0000-0000-0000-000000000000" {
+	if st := uuid.UUID(r.SessionToken).String(); st != "00000000-0000-0000-0000-000000000000" {
 		q.Set("sessiontoken", st)
 	}
 
@@ -698,8 +697,7 @@ func (r *PlaceAutocompleteRequest) params() url.Values {
 
 	q.Set("input", r.Input)
 
-	st := uuid.UUID(r.SessionToken).String()
-	if st != "00000000-0000-0000-0000-000000000000" {
+	if st := uuid.UUID(r.SessionToken).String(); st != "00000000-0000-0000-0000-000000000000" {
 		q.Set("sessiontoken", st)
 	}
 

--- a/places.go
+++ b/places.go
@@ -389,8 +389,9 @@ func (r *PlaceDetailsRequest) params() url.Values {
 		q.Set("fields", strings.Join(placeDetailsFieldMasksAsStringArray(r.Fields), ","))
 	}
 
-	if uuid.UUID(r.SessionToken).String() != "00000000-0000-0000-0000-000000000000" {
-		q.Set("sessiontoken", uuid.UUID(r.SessionToken).String())
+	st := uuid.UUID(r.SessionToken).String()
+	if st != "00000000-0000-0000-0000-000000000000" {
+		q.Set("sessiontoken", st)
 	}
 
 	if r.Region != "" {
@@ -676,10 +677,6 @@ func (c *Client) PlaceAutocomplete(ctx context.Context, r *PlaceAutocompleteRequ
 		return AutocompleteResponse{}, errors.New("maps: Input missing")
 	}
 
-	if uuid.UUID(r.SessionToken).String() == "00000000-0000-0000-0000-000000000000" {
-		return AutocompleteResponse{}, errors.New("maps: Session missing")
-	}
-
 	var response struct {
 		Predictions []AutocompletePrediction `json:"predictions,omitempty"`
 		commonResponse
@@ -700,7 +697,11 @@ func (r *PlaceAutocompleteRequest) params() url.Values {
 	q := make(url.Values)
 
 	q.Set("input", r.Input)
-	q.Set("sessiontoken", uuid.UUID(r.SessionToken).String())
+
+	st := uuid.UUID(r.SessionToken).String()
+	if st != "00000000-0000-0000-0000-000000000000" {
+		q.Set("sessiontoken", st)
+	}
 
 	if r.Offset > 0 {
 		q.Set("offset", strconv.FormatUint(uint64(r.Offset), 10))

--- a/places_test.go
+++ b/places_test.go
@@ -464,8 +464,7 @@ func TestPlaceAutocompleteMinimalRequestURL(t *testing.T) {
 }
 
 func TestPlaceAutocompleteMaximalRequestURL(t *testing.T) {
-	session := NewPlaceAutocompleteSessionToken()
-	expectedQuery := "components=country%3AES&input=quay+resteraunt+sydney&key=AIzaNotReallyAnAPIKey&language=es&location=1%2C2&offset=5&radius=10000&sessiontoken=" + uuid.UUID(session).String() + "&types=geocode"
+	expectedQuery := "components=country%3AES&input=quay+resteraunt+sydney&key=AIzaNotReallyAnAPIKey&language=es&location=1%2C2&offset=5&radius=10000&types=geocode"
 
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
@@ -478,14 +477,13 @@ func TestPlaceAutocompleteMaximalRequestURL(t *testing.T) {
 	}
 
 	r := &PlaceAutocompleteRequest{
-		Input:        "quay resteraunt sydney",
-		Offset:       5,
-		Location:     &LatLng{1.0, 2.0},
-		Radius:       10000,
-		Language:     "es",
-		Types:        placeType,
-		Components:   map[Component]string{ComponentCountry: "ES"},
-		SessionToken: session,
+		Input:      "quay resteraunt sydney",
+		Offset:     5,
+		Location:   &LatLng{1.0, 2.0},
+		Radius:     10000,
+		Language:   "es",
+		Types:      placeType,
+		Components: map[Component]string{ComponentCountry: "ES"},
 	}
 
 	_, err = c.PlaceAutocomplete(context.Background(), r)


### PR DESCRIPTION
Hi there!

This PR makes `sessiontoken` optional in AutoComplete request according to the [doc]( https://developers.google.com/places/web-service/autocomplete#session_tokens)

[Doc](https://developers.google.com/places/web-service/autocomplete#place_autocomplete_requests) says: 
```
Optional parameters:
sessiontoken — A random string which identifies...

...
If the sessiontoken parameter is omitted, each request is billed independently. 
```

@domesticmouse @broady check it please as soon as possible!

Thank you!