### PR TITLE
Do not return an error in StatusError() when the status is ZERO_RESULTS

### DIFF
--- a/client.go
+++ b/client.go
@@ -266,9 +266,10 @@ type commonResponse struct {
 	ErrorMessage string `json:"error_message"`
 }
 
-// StatusError returns an error iff this object has a non-OK Status.
+// StatusError returns an error if this object has a Status different
+// from OK or ZERO_RESULTS.
 func (c *commonResponse) StatusError() error {
-	if c.Status != "OK" {
+	if c.Status != "OK" && c.Status != "ZERO_RESULTS" {
 		return fmt.Errorf("maps: %s - %s", c.Status, c.ErrorMessage)
 	}
 	return nil

--- a/directions_test.go
+++ b/directions_test.go
@@ -467,6 +467,27 @@ func TestDirectionsRequestURL(t *testing.T) {
 	}
 }
 
+func TestDirectionsZeroResults(t *testing.T) {
+	server := mockServer(200, `{"routes" : [], "status" : "ZERO_RESULTS"}`)
+	defer server.Close()
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
+	r := &DirectionsRequest{
+		Origin:      "Boston",
+		Destination: "Paris",
+		Mode:        TravelModeBicycling,
+	}
+
+	routes, _, err := c.Directions(context.Background(), r)
+
+	if err != nil {
+		t.Errorf("Unexpected error for ZERO_RESULTS status")
+	}
+
+	if len(routes) != 0 {
+		t.Errorf("Unexpected response for ZERO_RESULTS status")
+	}
+}
+
 func TestTrafficModel(t *testing.T) {
 	expectedQuery := "departure_time=now&destination=Parramatta+Town+Hall&key=AIzaNotReallyAnAPIKey&mode=driving&origin=Sydney+Town+Hall&traffic_model=pessimistic"
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)

--- a/geocoding.go
+++ b/geocoding.go
@@ -45,10 +45,6 @@ func (c *Client) Geocode(ctx context.Context, r *GeocodingRequest) ([]GeocodingR
 		return nil, err
 	}
 
-	if response.Status == "ZERO_RESULTS" {
-		return []GeocodingResult{}, nil
-	}
-
 	if err := response.StatusError(); err != nil {
 		return nil, err
 	}
@@ -70,10 +66,6 @@ func (c *Client) ReverseGeocode(ctx context.Context, r *GeocodingRequest) ([]Geo
 
 	if err := c.getJSON(ctx, geocodingAPI, r, &response); err != nil {
 		return nil, err
-	}
-
-	if response.Status == "ZERO_RESULTS" {
-		return []GeocodingResult{}, nil
 	}
 
 	if err := response.StatusError(); err != nil {

--- a/geocoding_test.go
+++ b/geocoding_test.go
@@ -628,7 +628,7 @@ func TestCustomPassThroughGeocodingURL(t *testing.T) {
 }
 
 func TestGeocodingZeroResults(t *testing.T) {
-	server := mockServer(200, `{"status" : "ZERO_RESULTS"}`)
+	server := mockServer(200, `{"results" : [], "status" : "ZERO_RESULTS"}`)
 	defer server.Close()
 	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
 	r := &GeocodingRequest{
@@ -636,6 +636,29 @@ func TestGeocodingZeroResults(t *testing.T) {
 	}
 
 	response, err := c.Geocode(context.Background(), r)
+
+	if err != nil {
+		t.Errorf("Unexpected error for ZERO_RESULTS status")
+	}
+
+	if response == nil {
+		t.Errorf("Unexpected nil response for ZERO_RESULTS status")
+	}
+
+	if len(response) != 0 {
+		t.Errorf("Unexpected response for ZERO_RESULTS status")
+	}
+}
+
+func TestReverseGeocodingZeroResults(t *testing.T) {
+	server := mockServer(200, `{"results" : [], "status" : "ZERO_RESULTS"}`)
+	defer server.Close()
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
+	r := &GeocodingRequest{
+		LatLng: &LatLng{Lat: 28.0, Lng: 140.0},
+	}
+
+	response, err := c.ReverseGeocode(context.Background(), r)
 
 	if err != nil {
 		t.Errorf("Unexpected error for ZERO_RESULTS status")

--- a/places_test.go
+++ b/places_test.go
@@ -1115,3 +1115,100 @@ func TestFindPlaceFromText(t *testing.T) {
 		t.Errorf("expected %+v, was %+v", "Mongolian Grill Kirkland", resp.Candidates[0].Name)
 	}
 }
+
+func TestTextSearchZeroResults(t *testing.T) {
+	server := mockServer(200, `{"results" : [], "status" : "ZERO_RESULTS"}`)
+	defer server.Close()
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
+	r := &TextSearchRequest{
+		Query: "Nothing to see here",
+	}
+
+	resp, err := c.TextSearch(context.Background(), r)
+
+	if err != nil {
+		t.Errorf("Unexpected error for ZERO_RESULTS status")
+	}
+
+	if len(resp.Results) != 0 {
+		t.Errorf("Unexpected results for ZERO_RESULTS status")
+	}
+}
+
+func TestNearbySearchZeroResults(t *testing.T) {
+	server := mockServer(200, `{"results" : [], "status" : "ZERO_RESULTS"}`)
+	defer server.Close()
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
+	r := &NearbySearchRequest{
+		Location: &LatLng{28.0, 140.0},
+		Radius:   100,
+	}
+
+	resp, err := c.NearbySearch(context.Background(), r)
+
+	if err != nil {
+		t.Errorf("Unexpected error for ZERO_RESULTS status")
+	}
+
+	if len(resp.Results) != 0 {
+		t.Errorf("Unexpected results for ZERO_RESULTS status")
+	}
+}
+
+func TestFindPlaceFromTextZeroResults(t *testing.T) {
+	server := mockServer(200, `{"candidates" : [], "status" : "ZERO_RESULTS"}`)
+	defer server.Close()
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
+	r := &FindPlaceFromTextRequest{
+		Input:     "+12345506789",
+		InputType: FindPlaceFromTextInputTypeTextQuery,
+	}
+
+	resp, err := c.FindPlaceFromText(context.Background(), r)
+
+	if err != nil {
+		t.Errorf("Unexpected error for ZERO_RESULTS status")
+	}
+
+	if len(resp.Candidates) != 0 {
+		t.Errorf("Unexpected candidates for ZERO_RESULTS status")
+	}
+}
+
+func TestPlaceAutocompleteZeroResults(t *testing.T) {
+	server := mockServer(200, `{"predictions" : [], "status" : "ZERO_RESULTS"}`)
+	defer server.Close()
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
+	r := &PlaceAutocompleteRequest{
+		Input: "gobbledygook",
+	}
+
+	resp, err := c.PlaceAutocomplete(context.Background(), r)
+
+	if err != nil {
+		t.Errorf("Unexpected error for ZERO_RESULTS status")
+	}
+
+	if len(resp.Predictions) != 0 {
+		t.Errorf("Unexpected predictions for ZERO_RESULTS status")
+	}
+}
+
+func TestQueryAutocompleteZeroResults(t *testing.T) {
+	server := mockServer(200, `{"predictions" : [], "status" : "ZERO_RESULTS"}`)
+	defer server.Close()
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
+	r := &QueryAutocompleteRequest{
+		Input: "gobbledygook",
+	}
+
+	resp, err := c.QueryAutocomplete(context.Background(), r)
+
+	if err != nil {
+		t.Errorf("Unexpected error for ZERO_RESULTS status")
+	}
+
+	if len(resp.Predictions) != 0 {
+		t.Errorf("Unexpected predictions for ZERO_RESULTS status")
+	}
+}

--- a/timezone_test.go
+++ b/timezone_test.go
@@ -124,3 +124,25 @@ func TestTimezoneRequestURL(t *testing.T) {
 		t.Errorf("Got URL(s) %v, want %s", server.failed, expectedQuery)
 	}
 }
+
+func TestTimezoneZeroResults(t *testing.T) {
+	server := mockServer(200, `{"status" : "ZERO_RESULTS"}`)
+	defer server.Close()
+	c, _ := NewClient(WithAPIKey(apiKey), WithBaseURL(server.URL))
+
+	r := &TimezoneRequest{
+		Location:  &LatLng{28.0, 140.0},
+		Timestamp: time.Time{},
+	}
+
+	result, err := c.Timezone(context.Background(), r)
+
+	if err != nil {
+		t.Errorf("Unexpected error for ZERO_RESULTS status")
+	}
+
+	var empty TimezoneResult
+	if *result != empty {
+		t.Errorf("Unexpected result for ZERO_RESULTS status")
+	}
+}


### PR DESCRIPTION
This is meant as a first step to streamline error handling (see #135).
Instead of peppering the code with ZERO_RESULTS checks (680e071a043395a60a4e03ca3ab6ee011650a5fb and 57ebecb10c25dc67331ccc5a7b40a3fc0bd5ff0a), I think that StatusError() should simply not return an error when the status is ZERO_RESULTS.
This is actually in line with the [Python client](https://github.com/googlemaps/google-maps-services-python/blob/master/googlemaps/client.py#L284).