### PR TITLE
Add missing Marker scale parameter for static maps

### DIFF
--- a/staticmap.go
+++ b/staticmap.go
@@ -134,6 +134,8 @@ type Marker struct {
 	CustomIcon CustomIcon
 	// Location is the Marker position
 	Location []LatLng
+	// Scale is the Marker scale
+	Scale int
 }
 
 func (m Marker) String() string {
@@ -152,6 +154,10 @@ func (m Marker) String() string {
 
 		if m.Size != "" {
 			r = append(r, fmt.Sprintf("size:%s", m.Size))
+		}
+
+		if m.Scale != 0 {
+			r = append(r, fmt.Sprintf("scale:%d", m.Scale))
 		}
 	}
 

--- a/staticmap.go
+++ b/staticmap.go
@@ -104,6 +104,8 @@ type CustomIcon struct {
 	IconURL string
 	// Anchor sets how the icon is placed in relation to the specified markers locations
 	Anchor Anchor
+	// Scale is the custom icon scale
+	Scale int
 }
 
 func (c CustomIcon) String() string {
@@ -115,6 +117,10 @@ func (c CustomIcon) String() string {
 
 	if c.Anchor != "" {
 		r = append(r, fmt.Sprintf("anchor:%s", c.Anchor))
+	}
+
+	if c.Scale != 0 {
+		r = append(r, fmt.Sprintf("scale:%d", c.Scale))
 	}
 
 	return strings.Join(r, "|")
@@ -134,8 +140,6 @@ type Marker struct {
 	CustomIcon CustomIcon
 	// Location is the Marker position
 	Location []LatLng
-	// Scale is the Marker scale
-	Scale int
 }
 
 func (m Marker) String() string {
@@ -154,10 +158,6 @@ func (m Marker) String() string {
 
 		if m.Size != "" {
 			r = append(r, fmt.Sprintf("size:%s", m.Size))
-		}
-
-		if m.Scale != 0 {
-			r = append(r, fmt.Sprintf("scale:%d", m.Scale))
 		}
 	}
 

--- a/staticmap_test.go
+++ b/staticmap_test.go
@@ -103,8 +103,8 @@ func TestCustomIconMarkers(t *testing.T) {
 		Markers: []Marker{marker},
 	}
 
-	values := r.params()
-	if q := values.Encode(); q != "markers=icon%3Aicon%402x.png%7Canchor%3Atopleft%7Cscale%3A2%7C3.1225951401%2C101.6404967928" {
-		t.Errorf("Generated query string is wrong: %s", q)
+	markers := r.params().Get("markers")
+	if m := markers; m != "icon:icon@2x.png|anchor:topleft|scale:2|3.1225951401,101.6404967928" {
+		t.Errorf("Generated query string is wrong: %s", m)
 	}
 }

--- a/staticmap_test.go
+++ b/staticmap_test.go
@@ -83,3 +83,28 @@ func TestMapStyles(t *testing.T) {
 		t.Errorf("Generated query string is wrong: %s", q)
 	}
 }
+
+func TestCustomIconMarkers(t *testing.T) {
+	marker := Marker{
+		CustomIcon: CustomIcon{
+			IconURL: "icon@2x.png",
+			Anchor:  "topleft",
+			Scale:   2,
+		},
+		Location: []LatLng{
+			{
+				Lat: 3.1225951401,
+				Lng: 101.6404967928,
+			},
+		},
+	}
+
+	r := StaticMapRequest{
+		Markers: []Marker{marker},
+	}
+
+	values := r.params()
+	if q := values.Encode(); q != "markers=icon%3Aicon%402x.png%7Canchor%3Atopleft%7Cscale%3A2%7C3.1225951401%2C101.6404967928" {
+		t.Errorf("Generated query string is wrong: %s", q)
+	}
+}


### PR DESCRIPTION
The Marker's custom icon parameter has a scale descriptor that is undocumented. Found it here: https://stackoverflow.com/questions/10336646/how-can-i-use-high-resolution-custom-markers-with-the-scale-parameter-in-google

For example:
http://maps.googleapis.com/maps/api/staticmap?&size=600x400&scale=2&style=visibility:on%20&style=feature:water%7Celement:geometry%7Cvisibility:on%20&style=feature:landscape%7Celement:geometry%7Cvisibility:on%20&markers=scale:2%7Canchor:32,10%7Cicon:https://goo.gl/5y3S82%7CCanberra+ACT%20&markers=anchor:topleft%7Cicon:http://tinyurl.com/jrhlvu6%7CMelbourne+VIC%20&markers=anchor:topright%7Cicon:https://goo.gl/1oTJ9Y%7CSydney+NSW&key={YOUR_API_KEY}

Compare the **star** (scale=2) marker with the other two (no scale value, i.e. scale=1).