### PR TITLE
Add missing Region field for TextSearchRequest

### DIFF
--- a/places.go
+++ b/places.go
@@ -243,6 +243,10 @@ func (r *TextSearchRequest) params() url.Values {
 		q.Set("pagetoken", r.PageToken)
 	}
 
+	if r.Region != "" {
+		q.Set("region", r.Region)
+	}
+
 	return q
 }
 
@@ -280,6 +284,13 @@ type TextSearchRequest struct {
 	// PageToken parameter will execute a search with the same parameters used
 	// previously — all parameters other than PageToken will be ignored.
 	PageToken string
+	// The region code, specified as a ccTLD (country code top-level domain) two-character
+	// value. Most ccTLD codes are identical to ISO 3166-1 codes, with some exceptions.
+	// This parameter will only influence, not fully restrict, search results. If more
+	// relevant results exist outside of the specified region, they may be included. When
+	// this parameter is used, the country name is omitted from the resulting formatted_address
+	// for results in the specified region.
+	Region string
 }
 
 // PlacesSearchResponse is the response to a Places API Search request.

--- a/places_test.go
+++ b/places_test.go
@@ -292,7 +292,7 @@ func TestTextSearchMinimalRequestURL(t *testing.T) {
 }
 
 func TestTextSearchAllTheThingsRequestURL(t *testing.T) {
-	expectedQuery := "key=AIzaNotReallyAnAPIKey&language=es&location=1%2C2&maxprice=2&minprice=0&opennow=true&pagetoken=NextPageToken&query=Pizza+in+New+York&radius=1000&type=airport"
+	expectedQuery := "key=AIzaNotReallyAnAPIKey&language=es&location=1%2C2&maxprice=2&minprice=0&opennow=true&pagetoken=NextPageToken&query=Pizza+in+New+York&radius=1000&region=US&type=airport"
 
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
@@ -309,6 +309,7 @@ func TestTextSearchAllTheThingsRequestURL(t *testing.T) {
 		OpenNow:   true,
 		Type:      PlaceTypeAirport,
 		PageToken: "NextPageToken",
+		Region:    "US",
 	}
 
 	_, err := c.TextSearch(context.Background(), r)


### PR DESCRIPTION
As stated in the [doc](https://developers.google.com/places/web-service/search#TextSearchRequests), there is a region parameter which found in google-maps-services-python and google-maps-services-java but not in this repo.