### PR TITLE
Convert Path.Location to an encoded polyline string

### DIFF
--- a/staticmap.go
+++ b/staticmap.go
@@ -204,8 +204,20 @@ func (p Path) String() string {
 		r = append(r, "geodesic:true")
 	}
 
-	for _, l := range p.Location {
-		r = append(r, l.String())
+	if len(p.Location) == 0 {
+		return strings.Join(r, "|")
+	}
+
+	encodedLocationString := fmt.Sprintf("enc:%s", Encode(p.Location))
+	latLngsToString := make([]string, len(p.Location))
+	for i, l := range p.Location {
+		latLngsToString[i] = l.String()
+	}
+	locationString := strings.Join(latLngsToString, "|")
+	if len(locationString) > len(encodedLocationString) {
+		r = append(r, encodedLocationString)
+	} else {
+		r = append(r, latLngsToString...)
 	}
 	return strings.Join(r, "|")
 }


### PR DESCRIPTION
Hi,

In our company we have the use case to generate polylines with a significant number of Points.
As the current library does not use the Encode method, the url generated is too long.

This Pull Request permits to set an option to true (`UsePolylineEncoding`), to activate the Encoding option.

Regards