### PR TITLE
Add request exceeds error for PlacePhoto API.

### DIFF
--- a/places.go
+++ b/places.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"image"
 	"io"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -811,6 +812,10 @@ func (c *Client) PlacePhoto(ctx context.Context, r *PlacePhotoRequest) (PlacePho
 	resp, err := c.getBinary(ctx, placesPhotoAPI, r)
 	if err != nil {
 		return PlacePhotoResponse{}, err
+	}
+
+	if resp.statusCode == http.StatusForbidden {
+		return PlacePhotoResponse{}, errors.New("maps: request exceeds your available quota")
 	}
 
 	return PlacePhotoResponse{resp.contentType, resp.data}, nil


### PR DESCRIPTION
Add request exceeds error for PlacePhoto API.
Because not handling request exceeds error.

- Documents
https://developers.google.com/places/web-service/photos#place_photo_requests