### PR TITLE
Google Static Maps API: Added support for Marker using location address

### DIFF
--- a/staticmap.go
+++ b/staticmap.go
@@ -140,6 +140,8 @@ type Marker struct {
 	CustomIcon CustomIcon
 	// Location is the Marker position
 	Location []LatLng
+	// LocationAddress is the Marker position as a postal address or other geocodable location.
+	LocationAddress string
 }
 
 func (m Marker) String() string {
@@ -164,6 +166,10 @@ func (m Marker) String() string {
 	for _, l := range m.Location {
 		r = append(r, l.String())
 	}
+	if m.LocationAddress != "" {
+		r = append(r, m.LocationAddress)
+	}
+
 	return strings.Join(r, "|")
 }
 

--- a/staticmap_test.go
+++ b/staticmap_test.go
@@ -108,3 +108,24 @@ func TestCustomIconMarkers(t *testing.T) {
 		t.Errorf("Generated query string is wrong: %s", m)
 	}
 }
+
+func TestMarkersWithLocationAndAddress(t *testing.T) {
+	marker := Marker{
+		Location: []LatLng{
+			{
+				Lat: 3.1225951401,
+				Lng: 101.6404967928,
+			},
+		},
+		LocationAddress: "my Marker address",
+	}
+
+	r := StaticMapRequest{
+		Markers: []Marker{marker},
+	}
+
+	markers := r.params().Get("markers")
+	if m := markers; m != "3.1225951401,101.6404967928|my Marker address" {
+		t.Errorf("Generated query string is wrong: %s", m)
+	}
+}


### PR DESCRIPTION
I have a need to position a Marker using a postal address rather than the long,lat location.
The Google Static Maps API supports this, just this package was lacking the support.

Thanks for your time.