### PR TITLE
Add support for signing Static Maps API requests

### DIFF
--- a/directions.go
+++ b/directions.go
@@ -25,9 +25,10 @@ import (
 )
 
 var directionsAPI = &apiConfig{
-	host:            "https://maps.googleapis.com",
-	path:            "/maps/api/directions/json",
-	acceptsClientID: true,
+	host:             "https://maps.googleapis.com",
+	path:             "/maps/api/directions/json",
+	acceptsClientID:  true,
+	acceptsSignature: false,
 }
 
 // Directions issues the Directions request and retrieves the Response

--- a/distancematrix.go
+++ b/distancematrix.go
@@ -26,9 +26,10 @@ import (
 )
 
 var distanceMatrixAPI = &apiConfig{
-	host:            "https://maps.googleapis.com",
-	path:            "/maps/api/distancematrix/json",
-	acceptsClientID: true,
+	host:             "https://maps.googleapis.com",
+	path:             "/maps/api/distancematrix/json",
+	acceptsClientID:  true,
+	acceptsSignature: false,
 }
 
 // DistanceMatrix makes a Distance Matrix API request

--- a/elevation.go
+++ b/elevation.go
@@ -25,9 +25,10 @@ import (
 )
 
 var elevationAPI = &apiConfig{
-	host:            "https://maps.googleapis.com",
-	path:            "/maps/api/elevation/json",
-	acceptsClientID: true,
+	host:             "https://maps.googleapis.com",
+	path:             "/maps/api/elevation/json",
+	acceptsClientID:  true,
+	acceptsSignature: false,
 }
 
 // Elevation makes an Elevation API request

--- a/examples/staticmap/cmdline/main.go
+++ b/examples/staticmap/cmdline/main.go
@@ -30,7 +30,7 @@ import (
 var (
 	apiKey    = flag.String("key", "", "API Key for using Google Maps API.")
 	clientID  = flag.String("client_id", "", "ClientID for Maps for Work API access.")
-	signature = flag.String("signature", "", "Signature for Maps for Work API access.")
+	signature = flag.String("signature", "", "Signature for Maps for Work API access or optional APIs.")
 	center    = flag.String("center", "", "Center the center of the map, equidistant from all edges of the map.")
 	zoom      = flag.Int("zoom", -1, "Zoom the zoom level of the map, which determines the magnification level of the map.")
 	size      = flag.String("size", "", "Size defines the rectangular dimensions of the map image.")
@@ -60,7 +60,11 @@ func main() {
 	var client *maps.Client
 	var err error
 	if *apiKey != "" {
-		client, err = maps.NewClient(maps.WithAPIKey(*apiKey))
+		if *signature != "" {
+			client, err = maps.NewClient(maps.WithAPIKeyAndSignature(*apiKey, *signature))
+		} else {
+			client, err = maps.NewClient(maps.WithAPIKey(*apiKey))
+		}
 	} else if *clientID != "" || *signature != "" {
 		client, err = maps.NewClient(maps.WithClientIDAndSignature(*clientID, *signature))
 	} else {

--- a/geocoding.go
+++ b/geocoding.go
@@ -25,9 +25,10 @@ import (
 )
 
 var geocodingAPI = &apiConfig{
-	host:            "https://maps.googleapis.com",
-	path:            "/maps/api/geocode/json",
-	acceptsClientID: true,
+	host:             "https://maps.googleapis.com",
+	path:             "/maps/api/geocode/json",
+	acceptsClientID:  true,
+	acceptsSignature: false,
 }
 
 // Geocode makes a Geocoding API request

--- a/geolocation.go
+++ b/geolocation.go
@@ -23,9 +23,10 @@ import (
 )
 
 var geolocationAPI = &apiConfig{
-	host:            "https://www.googleapis.com",
-	path:            "/geolocation/v1/geolocate",
-	acceptsClientID: true,
+	host:             "https://www.googleapis.com",
+	path:             "/geolocation/v1/geolocate",
+	acceptsClientID:  true,
+	acceptsSignature: false,
 }
 
 // Geolocate makes a Geolocation API request

--- a/internal/signer.go
+++ b/internal/signer.go
@@ -29,12 +29,12 @@ func generateSignature(key []byte, message string) (string, error) {
 	return base64.URLEncoding.EncodeToString(mac.Sum(nil)), nil
 }
 
-// SignURL signs a url with a clientID and signature.
+// SignURL signs a url with a signature.
 // The signature is assumed to be in URL safe base64 encoding.
 // The returned signature string is URLEncoded.
 // See: https://developers.google.com/maps/documentation/business/webservices/auth#digital_signatures
-func SignURL(path, clientID string, signature []byte, q url.Values) (string, error) {
-	q.Set("client", clientID)
+// See: https://developers.google.com/maps/faq#using-google-maps-apis
+func SignURL(path string, signature []byte, q url.Values) (string, error) {
 	encodedQuery := q.Encode()
 	message := fmt.Sprintf("%s?%s", path, encodedQuery)
 	s, err := generateSignature(signature, message)

--- a/places.go
+++ b/places.go
@@ -31,9 +31,10 @@ import (
 )
 
 var placesNearbySearchAPI = &apiConfig{
-	host:            "https://maps.googleapis.com",
-	path:            "/maps/api/place/nearbysearch/json",
-	acceptsClientID: true,
+	host:             "https://maps.googleapis.com",
+	path:             "/maps/api/place/nearbysearch/json",
+	acceptsClientID:  true,
+	acceptsSignature: false,
 }
 
 // NearbySearch lets you search for places within a specified area. You can refine

--- a/roads.go
+++ b/roads.go
@@ -25,21 +25,24 @@ import (
 )
 
 var snapToRoadsAPI = &apiConfig{
-	host:            "https://roads.googleapis.com",
-	path:            "/v1/snapToRoads",
-	acceptsClientID: false,
+	host:             "https://roads.googleapis.com",
+	path:             "/v1/snapToRoads",
+	acceptsClientID:  false,
+	acceptsSignature: false,
 }
 
 var nearestRoadsAPI = &apiConfig{
-	host:            "https://roads.googleapis.com",
-	path:            "/v1/nearestRoads",
-	acceptsClientID: false,
+	host:             "https://roads.googleapis.com",
+	path:             "/v1/nearestRoads",
+	acceptsClientID:  false,
+	acceptsSignature: false,
 }
 
 var speedLimitsAPI = &apiConfig{
-	host:            "https://roads.googleapis.com",
-	path:            "/v1/speedLimits",
-	acceptsClientID: false,
+	host:             "https://roads.googleapis.com",
+	path:             "/v1/speedLimits",
+	acceptsClientID:  false,
+	acceptsSignature: false,
 }
 
 // SnapToRoad makes a Snap to Road API request

--- a/staticmap.go
+++ b/staticmap.go
@@ -30,9 +30,10 @@ import (
 )
 
 var staticMapAPI = &apiConfig{
-	host:            "https://maps.googleapis.com",
-	path:            "/maps/api/staticmap",
-	acceptsClientID: true,
+	host:             "https://maps.googleapis.com",
+	path:             "/maps/api/staticmap",
+	acceptsClientID:  true,
+	acceptsSignature: true,
 }
 
 // MapType (optional) defines the type of map to construct. There are several possible

--- a/timezone.go
+++ b/timezone.go
@@ -26,9 +26,10 @@ import (
 )
 
 var timezoneAPI = &apiConfig{
-	host:            "https://maps.googleapis.com",
-	path:            "/maps/api/timezone/json",
-	acceptsClientID: true,
+	host:             "https://maps.googleapis.com",
+	path:             "/maps/api/timezone/json",
+	acceptsClientID:  true,
+	acceptsSignature: false,
 }
 
 // Timezone makes a Timezone API request


### PR DESCRIPTION
Per [FAQ](https://developers.google.com/maps/faq#digsig):

> For a limited number of daily requests to the Maps Static and Street View Static APIs, the digital signature is optional. With that being said, we strongly recommend that you use both an API key and a digital signature to authenticate your requests, regardless of your usage.
