### PR TITLE
Places API: add missing user_ratings_total

### DIFF
--- a/places.go
+++ b/places.go
@@ -328,6 +328,8 @@ type PlacesSearchResult struct {
 	// Rating contains the place's rating, from 1.0 to 5.0, based on aggregated user
 	// reviews.
 	Rating float32 `json:"rating,omitempty"`
+	// UserRatingsTotal contains total number of the place's ratings
+	UserRatingsTotal int `json:"user_ratings_total,omitempty"`
 	// Types contains an array of feature types describing the given result.
 	Types []string `json:"types,omitempty"`
 	// OpeningHours may contain whether the place is open now or not.
@@ -469,6 +471,8 @@ type PlaceDetailsResult struct {
 	// Rating contains the place's rating, from 1.0 to 5.0, based on aggregated user
 	// reviews.
 	Rating float32 `json:"rating,omitempty"`
+	// UserRatingsTotal contains total number of the place's ratings
+	UserRatingsTotal int `json:"user_ratings_total,omitempty"`
 	// Types contains an array of feature types describing the given result.
 	Types []string `json:"types,omitempty"`
 	// OpeningHours may contain whether the place is open now or not.

--- a/types.go
+++ b/types.go
@@ -520,6 +520,7 @@ const (
 	PlaceDetailsFieldMaskPlaceID                  = PlaceDetailsFieldMask("place_id")
 	PlaceDetailsFieldMaskPriceLevel               = PlaceDetailsFieldMask("price_level")
 	PlaceDetailsFieldMaskRatings                  = PlaceDetailsFieldMask("rating")
+	PlaceDetailsFieldMaskUserRatingsTotal         = PlaceDetailsFieldMask("user_ratings_total")
 	PlaceDetailsFieldMaskReviews                  = PlaceDetailsFieldMask("reviews")
 	PlaceDetailsFieldMaskScope                    = PlaceDetailsFieldMask("scope")
 	PlaceDetailsFieldMaskTypes                    = PlaceDetailsFieldMask("types")
@@ -565,6 +566,8 @@ func ParsePlaceDetailsFieldMask(placeDetailsFieldMask string) (PlaceDetailsField
 		return PlaceDetailsFieldMaskPriceLevel, nil
 	case "rating":
 		return PlaceDetailsFieldMaskRatings, nil
+	case "user_ratings_total":
+		return PlaceDetailsFieldMaskUserRatingsTotal, nil
 	case "reviews":
 		return PlaceDetailsFieldMaskReviews, nil
 	case "scope":
@@ -613,6 +616,7 @@ const (
 	PlaceSearchFieldMaskPlaceID             = PlaceSearchFieldMask("place_id")
 	PlaceSearchFieldMaskPriceLevel          = PlaceSearchFieldMask("price_level")
 	PlaceSearchFieldMaskRating              = PlaceSearchFieldMask("rating")
+	PlaceSearchFieldMaskUserRatingsTotal    = PlaceSearchFieldMask("user_ratings_total")
 	PlaceSearchFieldMaskReference           = PlaceSearchFieldMask("reference")
 	PlaceSearchFieldMaskTypes               = PlaceSearchFieldMask("types")
 	PlaceSearchFieldMaskVicinity            = PlaceSearchFieldMask("vicinity")
@@ -648,6 +652,8 @@ func ParsePlaceSearchFieldMask(placeSearchFieldMask string) (PlaceSearchFieldMas
 		return PlaceSearchFieldMaskPriceLevel, nil
 	case "rating":
 		return PlaceSearchFieldMaskRating, nil
+	case "user_ratings_total":
+		return PlaceSearchFieldMaskUserRatingsTotal, nil
 	case "reference":
 		return PlaceSearchFieldMaskReference, nil
 	case "types":


### PR DESCRIPTION
There is a field called `user_ratings_total` that is missing from this Go API bindings implementation

Here you can find it on this page: 
https://developers.google.com/places/web-service/details#fields

You can also see this field in the test data https://github.com/googlemaps/google-maps-services-go/blob/master/places_test.go#L672

This PR is intended to add this missing field