### PR TITLE
Copy components values to keep original request not modified.

### DIFF
--- a/places.go
+++ b/places.go
@@ -727,10 +727,11 @@ func (r *PlaceAutocompleteRequest) params() url.Values {
 
 	var cf []string
 	for c, f := range r.Components {
+		fc := make([]string, len(f))
 		for i, v := range f {
-			f[i] = string(c) + ":" + v
+			fc[i] = string(c) + ":" + v
 		}
-		cf = append(cf, strings.Join(f, "|"))
+		cf = append(cf, strings.Join(fc, "|"))
 	}
 	if len(cf) > 0 {
 		q.Set("components", strings.Join(cf, "|"))


### PR DESCRIPTION
`func (r *PlaceAutocompleteRequest) params()` modifies `Components ` values, 
which may cause a bug if the same request value is used to make multiple requests (for example to do retries). 
That's why create a slice with field copies.