### PR TITLE
Add origin and distance_meters support for Places AutoComplete

### DIFF
--- a/places.go
+++ b/places.go
@@ -638,6 +638,9 @@ type AutocompleteResponse struct {
 type AutocompletePrediction struct {
 	// Description of the matched prediction.
 	Description string `json:"description,omitempty"`
+	// DistanceMeters is the straight-line distance from the prediction to the
+	// Origin if Origin was passed in the Query
+	DistanceMeters int `json:"distance_meters,omitempty"`
 	// PlaceID is the ID of the Place
 	PlaceID string `json:"place_id,omitempty"`
 	// Types is an array indicating the type of the address component.
@@ -726,6 +729,10 @@ func (r *PlaceAutocompleteRequest) params() url.Values {
 		q.Set("location", r.Location.String())
 	}
 
+	if r.Origin != nil {
+		q.Set("origin", r.Origin.String())
+	}
+
 	if r.Radius > 0 {
 		q.Set("radius", strconv.FormatUint(uint64(r.Radius), 10))
 	}
@@ -778,6 +785,9 @@ type PlaceAutocompleteRequest struct {
 	Offset uint
 	// Location is the point around which you wish to retrieve place information.
 	Location *LatLng
+	// Origin is the point from which to calculate the straight-line distance to the
+	// destination (returned as distance_meters).
+	Origin *LatLng
 	// Radius is the distance (in meters) within which to return place results. Note
 	// that setting a radius biases results to the indicated area, but may not fully
 	// restrict results to the specified area.

--- a/places_test.go
+++ b/places_test.go
@@ -465,7 +465,7 @@ func TestPlaceAutocompleteMinimalRequestURL(t *testing.T) {
 }
 
 func TestPlaceAutocompleteMaximalRequestURL(t *testing.T) {
-	expectedQuery := "components=country%3AES%7Ccountry%3AAU&input=quay+resteraunt+sydney&key=AIzaNotReallyAnAPIKey&language=es&location=1%2C2&offset=5&radius=10000&types=geocode"
+	expectedQuery := "components=country%3AES%7Ccountry%3AAU&input=quay+resteraunt+sydney&key=AIzaNotReallyAnAPIKey&language=es&location=1%2C2&offset=5&origin=1%2C2&radius=10000&types=geocode"
 
 	server := mockServerForQuery(expectedQuery, 200, `{"status":"OK"}"`)
 	defer server.s.Close()
@@ -481,6 +481,7 @@ func TestPlaceAutocompleteMaximalRequestURL(t *testing.T) {
 		Input:    "quay resteraunt sydney",
 		Offset:   5,
 		Location: &LatLng{1.0, 2.0},
+		Origin:   &LatLng{1.0, 2.0},
 		Radius:   10000,
 		Language: "es",
 		Types:    placeType,


### PR DESCRIPTION
Notes:
1) `orign` and `distance_meters` are described here: https://developers.google.com/places/web-service/autocomplete
2) I selected to unmarshal `distance_meters` into an int because I have never seen it return a float and googlemaps seems to use int for distances. However, I do not know if this is accurate - I could not find documentation and the other googlemaps libraries seem to also lack support for `origin` and `distance_meters`
3) I didn't see a place to squeeze in a test for `distance_meters` so I didn't add one. Afaik it would simply be an unmarshaling test anyways