### PR TITLE
feat: add ability to pass the experience id within the context

### DIFF
--- a/client.go
+++ b/client.go
@@ -133,6 +133,14 @@ func ExperienceIdContext(ctx context.Context, experienceIds ...string) context.C
 	return ctx
 }
 
+// ExperienceIdFromContext returns experienceIds from context if presented
+func ExperienceIdFromContext(ctx context.Context) []string {
+	if experiencesId := ctx.Value(contextExperienceId); experiencesId != nil {
+		return experiencesId.([]string)
+	}
+	return nil
+}
+
 // WithBaseURL configures a Maps API client with a custom base url
 func WithBaseURL(baseURL string) ClientOption {
 	return func(c *Client) error {
@@ -314,8 +322,8 @@ func (c *Client) setExperienceIdHeader(ctx context.Context, req *http.Request) {
 	if len(c.experienceId) > 0 {
 		ids = append(ids, c.experienceId...)
 	}
-	if experiencesId := ctx.Value(contextExperienceId); experiencesId != nil {
-		for _, v := range experiencesId.([]string) {
+	if experiencesId := ExperienceIdFromContext(ctx); experiencesId != nil {
+		for _, v := range experiencesId {
 			ids = append(ids, v)
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -50,8 +50,14 @@ type ClientOption func(*Client) error
 
 var defaultRequestsPerSecond = 50
 
+type contextKey string
+func (c contextKey) String() string {
+	return "maps " + string(c)
+}
+
 const (
 	ExperienceIdHeaderName = "X-GOOG-MAPS-EXPERIENCE-ID"
+	contextExperienceId    = contextKey("EXP-IDS")
 )
 
 // NewClient constructs a new Client which can make requests to the Google Maps
@@ -122,7 +128,7 @@ func WithAPIKeyAndSignature(apiKey, signature string) ClientOption {
 // in the post/get handlers. Useful if a customer uses one client instance per different experiences calls
 func ExperienceIdContext(ctx context.Context, experienceIds ...string) context.Context {
 	if ctx != nil {
-		return context.WithValue(ctx, ExperienceIdHeaderName, experienceIds)
+		return context.WithValue(ctx, contextExperienceId, experienceIds)
 	}
 	return ctx
 }
@@ -308,7 +314,7 @@ func (c *Client) setExperienceIdHeader(ctx context.Context, req *http.Request) {
 	if len(c.experienceId) > 0 {
 		ids = append(ids, c.experienceId...)
 	}
-	if experiencesId := ctx.Value(ExperienceIdHeaderName); experiencesId != nil {
+	if experiencesId := ctx.Value(contextExperienceId); experiencesId != nil {
 		for _, v := range experiencesId.([]string) {
 			ids = append(ids, v)
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -15,6 +15,7 @@
 package maps
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -69,20 +70,45 @@ func TestClientSetExperienceIdHeader(t *testing.T) {
 	// slice has two elements
 	c.experienceId = ids
 	req, _ := http.NewRequest("GET", "/", nil)
-	c.setExperienceIdHeader(req)
-	assert.Equal(t, req.Header.Get(ExperienceIdHeaderName), strings.Join(ids, ","))
+	c.setExperienceIdHeader(context.Background(), req)
+	assert.Equal(t, strings.Join(ids, ","), req.Header.Get(ExperienceIdHeaderName))
 
 	// slice is nil
 	c.experienceId = nil
 	req, _ = http.NewRequest("GET", "/", nil)
-	c.setExperienceIdHeader(req)
-	assert.Equal(t, req.Header.Get(ExperienceIdHeaderName), "")
+	c.setExperienceIdHeader(context.Background(), req)
+	assert.Equal(t, "", req.Header.Get(ExperienceIdHeaderName))
 
 	// slice is empty
 	c.experienceId = []string{}
 	req, _ = http.NewRequest("GET", "/", nil)
-	c.setExperienceIdHeader(req)
-	assert.Equal(t, req.Header.Get(ExperienceIdHeaderName), "")
+	c.setExperienceIdHeader(context.Background(), req)
+	assert.Equal(t, "", req.Header.Get(ExperienceIdHeaderName))
+
+	var ctx context.Context
+	// context has one element
+	c.experienceId = []string{}
+	ctx = context.Background()
+	ctx = ExperienceIdContext(ctx, "foo")
+	req, _ = http.NewRequest("GET", "/", nil)
+	c.setExperienceIdHeader(ctx, req)
+	assert.Equal(t, "foo", req.Header.Get(ExperienceIdHeaderName))
+
+	// context has two elements
+	c.experienceId = []string{}
+	ctx = context.Background()
+	ctx = ExperienceIdContext(ctx, ids...)
+	req, _ = http.NewRequest("GET", "/", nil)
+	c.setExperienceIdHeader(ctx, req)
+	assert.Equal(t, strings.Join(ids, ","), req.Header.Get(ExperienceIdHeaderName))
+
+	// context has two elements and client has two elements
+	c.experienceId = ids
+	ctx = context.Background()
+	ctx = ExperienceIdContext(ctx, ids...)
+	req, _ = http.NewRequest("GET", "/", nil)
+	c.setExperienceIdHeader(ctx, req)
+	assert.Equal(t, strings.Join(ids, ",") + "," + strings.Join(ids, ","), req.Header.Get(ExperienceIdHeaderName))
 }
 
 func TestClientExperienceIdSample(t *testing.T) {


### PR DESCRIPTION
In scenario when singleton SDK client used to make calls for different customers, setting the [experienceId](https://developers.google.com/maps/documentation/one_per_ride/managing-trips#go_example_2) explicitly for every new call leads to the race conditions between the different requests.

I propose this PR to add ability passing the experienceId using context.