### PR TITLE
fix: Add Language to FindPlaceFromTextRequest

### DIFF
--- a/places.go
+++ b/places.go
@@ -920,6 +920,9 @@ type FindPlaceFromTextRequest struct {
 	// should be filled in.
 	Fields []PlaceSearchFieldMask
 
+	// Language specifies the language in which to return results. Optional.
+	Language string
+
 	// LocationBias is the type of location bias to apply to this request
 	LocationBias FindPlaceFromTextLocationBiasType
 
@@ -948,6 +951,10 @@ func (r *FindPlaceFromTextRequest) params() url.Values {
 
 	if len(r.Fields) > 0 {
 		q.Set("fields", strings.Join(placeSearchFieldMasksAsStringArray(r.Fields), ","))
+	}
+
+	if r.Language != "" {
+		q.Set("language", r.Language)
 	}
 
 	if r.LocationBias != "" {


### PR DESCRIPTION
This adds the `Language` field to `FindPlaceFromTextRequest`.  For more information, see:
https://developers.google.com/maps/documentation/places/web-service/search
