### PR TITLE
fix: add missing space in comment

### DIFF
--- a/places.go
+++ b/places.go
@@ -444,7 +444,7 @@ type PlaceDetailsRequest struct {
 	// ReviewsSort specifies the sorting method to use when returning reviews.
 	// Can be set to most_relevant (default) or newest.
 	//
-	//For most_relevant (default), reviews are sorted by relevance; the service
+	// For most_relevant (default), reviews are sorted by relevance; the service
 	// will bias the results to return reviews originally written in the
 	// preferred language.
 	// For newest, reviews are sorted in chronological order; the preferred


### PR DESCRIPTION
Just noticed a missing space in a comment while browsing the code. Thought I'd fix it—simple change, happy to help! 😊

---

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

